### PR TITLE
Run security scan as part of the build process

### DIFF
--- a/vars/govuk.groovy
+++ b/vars/govuk.groovy
@@ -153,7 +153,9 @@ def nonDockerBuildTasks(options, jobName, repoName) {
   }
 
   stage("Security analysis") {
-    runBrakemanSecurityScanner(repoName)
+    if (options.brakeman) {
+      runBrakemanSecurityScanner(repoName)
+    }
   }
 
   if (hasLint()) {

--- a/vars/govuk.groovy
+++ b/vars/govuk.groovy
@@ -152,6 +152,10 @@ def nonDockerBuildTasks(options, jobName, repoName) {
     isGem() ? bundleGem() : bundleApp()
   }
 
+  stage("Security analysis") {
+    runBrakemanSecurityScanner(repoName)
+  }
+
   if (hasLint()) {
     stage("Lint Ruby") {
       rubyLinter("app lib spec test")
@@ -242,6 +246,35 @@ def dockerBuildTasks(options, jobName) {
         pushDockerImageToGCR(jobName, env.BRANCH_NAME)
       }
     }
+  }
+}
+
+/**
+ * Run the brakeman security scanner against the current project
+ *
+ * @param repoName Name of the alphagov repository
+ */
+def runBrakemanSecurityScanner(repoName) {
+  // Install the brakeman gem and parse the output to retrieve the version we
+  // just installed. We'll use that version to run the brakeman binary. We need
+  // to do this because we can't just `gem install` the gem on Jenkins and want
+  // to prevent having to add the gem to every Gemfile.
+  def gemVersion = sh(
+    script: "gem install --no-document -q --install-dir ${JENKINS_HOME}/manually-installed-gems brakeman | grep 'Successfully installed brakeman'",
+    returnStdout: true
+  ).replaceAll("Successfully installed ", "").trim()
+
+  // Run brakeman's executable. If it finds security alerts it will return with
+  // an exited code other than 0.
+  def brakemanExitCode = sh(
+    script: "${JENKINS_HOME}/manually-installed-gems/gems/${gemVersion}/bin/brakeman .",
+    returnStatus: true
+  )
+
+  if (brakemanExitCode == 0) {
+    setBuildStatus("security", getFullCommitHash(), "No security issues found", "SUCCESS", repoName)
+  } else {
+    setBuildStatus("security", getFullCommitHash(), "Brakeman found security issues", "FAILURE", repoName)
   }
 }
 

--- a/vars/govuk.groovy
+++ b/vars/govuk.groovy
@@ -73,7 +73,7 @@ def buildProject(Map options = [:]) {
     }
 
     if (params.IS_SCHEMA_TEST) {
-      setBuildStatus(jobName, params.SCHEMA_COMMIT, "Downstream ${jobName} job is building on Jenkins", 'PENDING')
+      setBuildStatus(jobName, params.SCHEMA_COMMIT, "Downstream ${jobName} job is building on Jenkins", 'PENDING', 'govuk-content-schemas')
     }
 
     stage("Checkout") {
@@ -129,7 +129,7 @@ def buildProject(Map options = [:]) {
       }
     }
     if (params.IS_SCHEMA_TEST) {
-      setBuildStatus(jobName, params.SCHEMA_COMMIT, "Downstream ${jobName} job succeeded on Jenkins", 'SUCCESS')
+      setBuildStatus(jobName, params.SCHEMA_COMMIT, "Downstream ${jobName} job succeeded on Jenkins", 'SUCCESS', 'govuk-content-schemas')
     }
 
   } catch (e) {
@@ -139,7 +139,7 @@ def buildProject(Map options = [:]) {
           recipients: 'govuk-ci-notifications@digital.cabinet-office.gov.uk',
           sendToIndividuals: true])
     if (params.IS_SCHEMA_TEST) {
-      setBuildStatus(jobName, params.SCHEMA_COMMIT, "Downstream ${jobName} job failed on Jenkins", 'FAILED')
+      setBuildStatus(jobName, params.SCHEMA_COMMIT, "Downstream ${jobName} job failed on Jenkins", 'FAILED', 'govuk-content-schemas')
     }
     throw e
   }
@@ -865,12 +865,13 @@ def uploadArtefactToS3(artefact_path, s3_path){
  * @param commit SHA of the triggering commit on govuk-content-schemas
  * @param message The message to report
  * @param state The build state: one of PENDING, SUCCESS, FAILED
+ * @param repoName The alphagov repository
  */
-def setBuildStatus(jobName, commit, message, state) {
+def setBuildStatus(jobName, commit, message, state, repoName) {
   step([
       $class: "GitHubCommitStatusSetter",
       commitShaSource: [$class: "ManuallyEnteredShaSource", sha: commit],
-      reposSource: [$class: "ManuallyEnteredRepositorySource", url: "https://github.com/alphagov/govuk-content-schemas"],
+      reposSource: [$class: "ManuallyEnteredRepositorySource", url: "https://github.com/alphagov/${repoName}"],
       contextSource: [$class: "ManuallyEnteredCommitContextSource", context: "continuous-integration/jenkins/${jobName}"],
       errorHandlers: [[$class: "ChangingBuildStatusErrorHandler", result: "UNSTABLE"]],
       statusResultSource: [ $class: "ConditionalStatusResultSource", results: [[$class: "AnyBuildResult", message: message, state: state]] ]


### PR DESCRIPTION
This PR makes the default `buildProject` run the [brakeman gem](https://brakemanscanner.org/) during all builds. 

Brakeman is a static analysis tool that will analyse the application and warn of any security issues. It detects things like possible SQL injections and other common attacks. It would have prevented https://github.com/alphagov/content-performance-manager/pull/526 from being introduced. Unfortunately, Brakeman sometimes surfaces false positives, so work may be required to rewrite code that brakeman thinks is fine.

To avoid instantly breaking the tests for all applications, the script currently reports the result of the security check separately to GitHub. This will allow us to fix any issues without disrupting the workflow. In a couple of weeks we should make a security check pass required (by [adding it to govuk-saas-config](https://github.com/alphagov/govuk-saas-config/blob/7b05f9bc8c31366b34805dbe4bfdf75e24241eef/github/lib/configure_repo.rb#L71)).

I've tested this against content-performance-manager (which still has some issues - https://github.com/alphagov/content-performance-manager/pull/529) and collections (which doesn't - https://github.com/alphagov/collections/pull/525).

## What it looks like

A failing test looks like this (merging is still possible):

<img width="779" alt="screen shot 2018-02-28 at 21 25 25" src="https://user-images.githubusercontent.com/233676/36832738-a2d5136c-1d24-11e8-85a4-b1afadb765d4.png">

When all are passing, it looks like this:

<img width="774" alt="screen shot 2018-02-28 at 21 41 27" src="https://user-images.githubusercontent.com/233676/36832753-b42899d6-1d24-11e8-92b7-9c880889327e.png">

https://trello.com/c/sMXrGrql (Senior tech board)
