### PR TITLE
Remove the --cached option along with the --diff option

### DIFF
--- a/vars/govuk.groovy
+++ b/vars/govuk.groovy
@@ -512,8 +512,8 @@ def rubyLinter(String dirs = 'app spec lib', boolean lintDiff) {
     echo 'Running Ruby linter'
 
     withStatsdTiming("ruby_lint") {
-      sh("bundle exec govuk-lint-ruby ${lintDiff ? '--diff' : ''} \
-         --cached \
+      sh("bundle exec govuk-lint-ruby \
+         ${lintDiff ? '--diff --cached' : ''} \
          --format html --out rubocop-${GIT_COMMIT}.html \
          --format clang \
          ${dirs}"


### PR DESCRIPTION
If rubyLintDiff is false. For some reason, --cached becomes an invalid
option if --diff isn't used.