### PR TITLE
Specify the lintDiff default in rubyLinter as well

### DIFF
--- a/vars/govuk.groovy
+++ b/vars/govuk.groovy
@@ -506,7 +506,7 @@ def setEnvGitCommit() {
 /**
  * Runs the ruby linter. Only lint commits that are not in master.
  */
-def rubyLinter(String dirs = 'app spec lib', boolean lintDiff) {
+def rubyLinter(String dirs = 'app spec lib', boolean lintDiff = true) {
   setEnvGitCommit()
   if (!isCurrentCommitOnMaster()) {
     echo 'Running Ruby linter'


### PR DESCRIPTION
To avoid breaking code which is calling this function directly.