### PR TITLE
Set a fake SECRET_KEY_BASE when precompiling assets

### DIFF
--- a/vars/govuk.groovy
+++ b/vars/govuk.groovy
@@ -538,7 +538,7 @@ def sassLinter(String dirs = 'app/assets/stylesheets') {
 def precompileAssets() {
   echo 'Precompiling the assets'
   withStatsdTiming("assets_precompile") {
-    sh('RAILS_ENV=production GOVUK_WEBSITE_ROOT=http://www.test.gov.uk GOVUK_APP_DOMAIN=test.gov.uk GOVUK_APP_DOMAIN_EXTERNAL=test.gov.uk GOVUK_ASSET_ROOT=https://static.test.gov.uk GOVUK_ASSET_HOST=https://static.test.gov.uk bundle exec rake assets:clobber assets:precompile')
+    sh('RAILS_ENV=production SECRET_KEY_BASE=1 GOVUK_WEBSITE_ROOT=http://www.test.gov.uk GOVUK_APP_DOMAIN=test.gov.uk GOVUK_APP_DOMAIN_EXTERNAL=test.gov.uk GOVUK_ASSET_ROOT=https://static.test.gov.uk GOVUK_ASSET_HOST=https://static.test.gov.uk bundle exec rake assets:clobber assets:precompile')
   }
 }
 


### PR DESCRIPTION
This commit sets a fake `SECRET_KEY_BASE` when precompiling assets. This is because starting with Rails 5.2, `SECRET_KEY_BASE` is required when running any command, and CI doesn't have access to this value when running with `RAILS_ENV=production`. This worked previously since a missing `SECRET_KEY_BASE` would only generate a warning rather than an exception.