### PR TITLE
Always pull latest version when building a docker image

### DIFF
--- a/vars/govuk.groovy
+++ b/vars/govuk.groovy
@@ -824,7 +824,7 @@ def hasDockerfile() {
 def buildDockerImage(imageName, tagName, quiet = false) {
   validateDockerFileRubyVersion()
   tagName = safeDockerTag(tagName)
-  args = quiet ? "--quiet ." : "."
+  args = "${quiet ? '--quiet' : ''} ."
   docker.build("govuk/${imageName}:${tagName}", args)
 }
 

--- a/vars/govuk.groovy
+++ b/vars/govuk.groovy
@@ -824,7 +824,7 @@ def hasDockerfile() {
 def buildDockerImage(imageName, tagName, quiet = false) {
   validateDockerFileRubyVersion()
   tagName = safeDockerTag(tagName)
-  args = "${quiet ? '--quiet' : ''} ."
+  args = "${quiet ? '--quiet' : ''} --pull ."
   docker.build("govuk/${imageName}:${tagName}", args)
 }
 


### PR DESCRIPTION
This should fix problems we're seeing with older base images which are causing builds to fail as we've set up the Dockerfile assuming a more recent build image.