### PR TITLE
Add optional check for JSONB and BRIN in the database schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ extraParameters | Provide details here of any extra parameters that can be used 
 extraRubyVersions | Ruby versions to run the tests against in addition to the versions currently supported by all GOV.UK applications. Only applies to gems because they may be used in projects with different Ruby versions. | `[]`
 newStyleDockerTags | Tag docker images with timestamp and git SHA rather than the default of the build number repoName Provide this if the Github Repo name for the app is different to the jenkins job name. | `false`
 overrideTestTask | A closure containing commands to run to test the project. This will run instead of the default `bundle exec rake` |
+postgres96Lint | Whether or not to forbid newer postgres features | `true`
 publishingE2ETests | Whether or not to run the Publishing end-to-end tests. | `false`
 rubyLintDiff | Whether or not to pass the `--diff` option to `govuk-lint-ruby` | `true`
 sassLint | Whether or not to run the SASS linter | `true`

--- a/vars/govuk.groovy
+++ b/vars/govuk.groovy
@@ -174,6 +174,12 @@ def nonDockerBuildTasks(options, jobName, repoName) {
     echo "WARNING: You do not have SASS linting turned on. Please install govuk-lint and enable."
   }
 
+  if (options.postgres96Lint != false) {
+    stage("Check for Postgres 9.6 features") {
+      postgres96Linter()
+    }
+  }
+
   if (options.beforeTest) {
     echo "Running pre-test tasks"
     options.beforeTest.call()
@@ -529,6 +535,17 @@ def sassLinter(String dirs = 'app/assets/stylesheets') {
   echo 'Running SASS linter'
   withStatsdTiming("sass_lint") {
     sh("bundle exec govuk-lint-sass ${dirs}")
+  }
+}
+
+/**
+ * Check for postgres 9.6 features: jsonb and brin
+ */
+def postgres96Linter(String base = 'master', String schema = 'db/schema.rb') {
+  echo 'Running Postgres 9.6 linter'
+  withStatsdTiming("postgres96_lint") {
+    sh("! git diff master ${base} -- ${file} | grep -i brin")
+    sh("! git diff master ${base} -- ${file} | grep -i jsonb")
   }
 }
 


### PR DESCRIPTION
This is a very simple check, but will hopefully suffice for the little time there is remaining before we move everything over to AWS (and so the same version of postgres).

This is just a simple text match, knowing nothing about the format of an ActiveRecord schema; so for instance a column called "brin" would be rejected.  But we only check the diff against master, which should help to reduce false positives; and it can always be disabled.

---

[Trello card](https://trello.com/c/sX8BEAR3/199-postgres-96-on-integration-follow-up)