### PR TITLE
Don't run the "render inline" check

### DIFF
--- a/vars/govuk.groovy
+++ b/vars/govuk.groovy
@@ -275,7 +275,7 @@ def runBrakemanSecurityScanner(repoName) {
   // Run brakeman's executable. If it finds security alerts it will return with
   // an exited code other than 0.
   def brakemanExitCode = sh(
-    script: "${JENKINS_HOME}/manually-installed-gems/gems/${gemVersion}/bin/brakeman .",
+    script: "${JENKINS_HOME}/manually-installed-gems/gems/${gemVersion}/bin/brakeman . --except CheckRenderInline",
     returnStatus: true
   )
 


### PR DESCRIPTION
This disables the `CheckRenderInline` brakeman check because it's giving out false positives.

CheckRenderInline is supposed to warn against controller code like this:

```rb
def show
  render text: "You searched for #{params[:user_input]}"
end
```

In the context of controllers, `text` is a special option that will make Rails return a plain text response instead of HTML (like `render json: []` will render a JSON response). The method does not escape the user input, so is vulnerable to cross site scripting attacks.

However, in the GOV.UK components system, we use `text` as a local variable to be passed into a component. For example:

```ruby
<%= render "govuk_publishing_components/components/lead_paragraph", { text: @document.summary } %>
```

https://govuk-publishing-components.herokuapp.com/component-guide/lead_paragraph

This means `CheckRenderInline` incorrectly thinks we're rendering text, and throw up a warning:

```sh
Confidence: Medium
Category: Cross-Site Scripting
Check: RenderInline
Message: Unescaped model attribute rendered inline
Code: render(text => Document.find(params[:id]).summary, {})
File: app/views/documents/show.html.erb
Line: 7
```