### PR TITLE
Automatically run Brakeman for Rails apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Parameter | Description | Default
 --- | --- | ---
 afterTest | A closure containing commands to run after the test stage, such as report publishing |
 beforeTest | A closure containing commands to run before the test stage, such as environment variable configuration
-brakeman | Whether or not to run the Brakeman security scanner | `false`
+brakeman | Whether or not to run the Brakeman security scanner | `true` if a Rails app, otherwise `false`
 extraParameters | Provide details here of any extra parameters that can be used to configure this build.  See: https://jenkins.io/doc/pipeline/steps/workflow-multibranch/#code-properties-code-set-job-properties for details on the format and structure of these extra parameters. |
 extraRubyVersions | Ruby versions to run the tests against in addition to the versions currently supported by all GOV.UK applications. Only applies to gems because they may be used in projects with different Ruby versions. | `[]`
 newStyleDockerTags | Tag docker images with timestamp and git SHA rather than the default of the build number repoName Provide this if the Github Repo name for the app is different to the jenkins job name. | `false`

--- a/vars/govuk.groovy
+++ b/vars/govuk.groovy
@@ -153,7 +153,7 @@ def nonDockerBuildTasks(options, jobName, repoName) {
   }
 
   stage("Security analysis") {
-    if (options.brakeman) {
+    if (isRails() || options.brakeman) {
       runBrakemanSecurityScanner(repoName)
     }
   }
@@ -807,6 +807,15 @@ def hasLint() {
  */
 def isGem() {
   sh(script: "ls | grep gemspec", returnStatus: true) == 0
+}
+
+/**
+ * Is this a Rails app?
+ *
+ * Determined by checking the presence of "rails" in the `Gemfile`.
+ */
+def isRails() {
+  sh(script: "grep rails Gemfile", returnStatus: true) == 0
 }
 
 /**


### PR DESCRIPTION
We've enabled Brakeman on all our apps individually now so we should start to run it automatically so that new apps will get the security checks.

[Trello Card](https://trello.com/c/JyrOAef3/363-fix-sql-injection-vulnerabilities-in-govuk-applications)