### PR TITLE
Enable parallel linting for Ruby

### DIFF
--- a/vars/govuk.groovy
+++ b/vars/govuk.groovy
@@ -519,6 +519,7 @@ def rubyLinter(String dirs = 'app spec lib', boolean lintDiff = true) {
 
     withStatsdTiming("ruby_lint") {
       sh("bundle exec govuk-lint-ruby \
+         --parallel \
          ${lintDiff ? '--diff --cached' : ''} \
          --format html --out rubocop-${GIT_COMMIT}.html \
          --format clang \


### PR DESCRIPTION
This results in quite a big speedup, on my system for example, for
Whitehall, it drops from ~40 seconds to ~8 seconds.