### PR TITLE
Turn on rails-specific linting for ruby apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,4 +77,5 @@ overrideTestTask | A closure containing commands to run to test the project. Thi
 postgres96Lint | Whether or not to forbid newer postgres features | `true`
 publishingE2ETests | Whether or not to run the Publishing end-to-end tests. | `false`
 rubyLintDiff | Whether or not to pass the `--diff` option to `govuk-lint-ruby` | `true`
+rubyLintRails | Whether or not to pass the `--rails` option to `govuk-lint-ruby` | `false`
 sassLint | Whether or not to run the SASS linter | `true`

--- a/vars/govuk.groovy
+++ b/vars/govuk.groovy
@@ -160,7 +160,7 @@ def nonDockerBuildTasks(options, jobName, repoName) {
 
   if (hasLint()) {
     stage("Lint Ruby") {
-      rubyLinter("app lib spec test", options.get('rubyLintDiff', true))
+      rubyLinter("app lib spec test", options.get('rubyLintDiff', true), options.get('rubyLintRails', false))
     }
   } else {
     echo "WARNING: You do not have Ruby linting turned on. Please install govuk-lint and enable."
@@ -512,7 +512,7 @@ def setEnvGitCommit() {
 /**
  * Runs the ruby linter. Only lint commits that are not in master.
  */
-def rubyLinter(String dirs = 'app spec lib', boolean lintDiff = true) {
+def rubyLinter(String dirs = 'app spec lib', boolean lintDiff, boolean lintRails) {
   setEnvGitCommit()
   if (!isCurrentCommitOnMaster()) {
     echo 'Running Ruby linter'
@@ -521,6 +521,7 @@ def rubyLinter(String dirs = 'app spec lib', boolean lintDiff = true) {
       sh("bundle exec govuk-lint-ruby \
          --parallel \
          ${lintDiff ? '--diff --cached' : ''} \
+         ${lintRails ? '--rails' : '' } \
          --format html --out rubocop-${GIT_COMMIT}.html \
          --format clang \
          ${dirs}"


### PR DESCRIPTION
Rails apps have some specific linting checks in govuk-lint-ruby, which
new apps could benefit from - this shouldn't affect existing apps, as
we only lint the diff by default.