### PR TITLE
Set default args for rubyLinter

### DIFF
--- a/vars/govuk.groovy
+++ b/vars/govuk.groovy
@@ -512,7 +512,7 @@ def setEnvGitCommit() {
 /**
  * Runs the ruby linter. Only lint commits that are not in master.
  */
-def rubyLinter(String dirs = 'app spec lib', boolean lintDiff, boolean lintRails) {
+def rubyLinter(String dirs = 'app spec lib', boolean lintDiff = true, boolean lintRails = false) {
   setEnvGitCommit()
   if (!isCurrentCommitOnMaster()) {
     echo 'Running Ruby linter'


### PR DESCRIPTION
These were removed in https://github.com/alphagov/govuk-jenkinslib/pull/21 and is causing jobs that use this method to fail e.g: https://github.com/alphagov/govuk-developer-docs/blob/master/Jenkinsfile#L39