### PR TITLE
Make dirs configurable for ruby linting

### DIFF
--- a/vars/govuk.groovy
+++ b/vars/govuk.groovy
@@ -160,7 +160,7 @@ def nonDockerBuildTasks(options, jobName, repoName) {
 
   if (hasLint()) {
     stage("Lint Ruby") {
-      rubyLinter("app lib spec test", options.get('rubyLintDiff', true), options.get('rubyLintRails', false))
+      rubyLinter(options.get('rubyLintDirs', "app lib spec test"), options.get('rubyLintDiff', true), options.get('rubyLintRails', false))
     }
   } else {
     echo "WARNING: You do not have Ruby linting turned on. Please install govuk-lint and enable."


### PR DESCRIPTION
One specific directory that isn't normally linted is 'db', for which
we've seen some helpful checks fail in Content Publisher. This PR
enables us to extend the set of directories being linted by CI to better
match the local linting we do in development.