### PR TITLE
Improve rails detection

### DIFF
--- a/vars/govuk.groovy
+++ b/vars/govuk.groovy
@@ -822,7 +822,7 @@ def isGem() {
  * Determined by checking the presence of "rails" in the `Gemfile`.
  */
 def isRails() {
-  sh(script: "grep rails Gemfile", returnStatus: true) == 0
+  new File("bin/rails").exists()
 }
 
 /**


### PR DESCRIPTION
Use the existance of bin/rails, as this is more reliable than looking
in the Gemfile, which can easily be confused by a comment.