### PR TITLE
Remove lintRails option for rubyLinter

### DIFF
--- a/vars/govuk.groovy
+++ b/vars/govuk.groovy
@@ -517,7 +517,7 @@ def setEnvGitCommit() {
 /**
  * Runs the ruby linter. Only lint commits that are not in master.
  */
-def rubyLinter(String dirs = 'app spec lib', boolean lintDiff = true, boolean lintRails = false) {
+def rubyLinter(String dirs = 'app spec lib', boolean lintDiff = true) {
   setEnvGitCommit()
   if (!isCurrentCommitOnMaster()) {
     echo 'Running Ruby linter'
@@ -526,7 +526,6 @@ def rubyLinter(String dirs = 'app spec lib', boolean lintDiff = true, boolean li
       sh("bundle exec govuk-lint-ruby \
          --parallel \
          ${lintDiff ? '--diff --cached' : ''} \
-         ${lintRails ? '--rails' : '' } \
          --format html --out rubocop-${GIT_COMMIT}.html \
          --format clang \
          ${dirs}"


### PR DESCRIPTION
This should be specified in .rubocop.yml instead.