### PR TITLE
Drop support for ruby-2.3

### DIFF
--- a/vars/govuk.groovy
+++ b/vars/govuk.groovy
@@ -646,7 +646,7 @@ def runTests(String test_task = 'default') {
  * addition to the versions currently supported by all GOV.UK applications
  */
 def testGemWithAllRubies(extraRubyVersions = []) {
-  def rubyVersions = ["2.3", "2.4", "2.5"]
+  def rubyVersions = ["2.4", "2.5"]
 
   rubyVersions.addAll(extraRubyVersions)
 


### PR DESCRIPTION
Everything is on 2.5.1, so all we get by checking 2.3 is failed builds when things require a newer version of ruby, like the xray gem.