### PR TITLE
Create Mongoid indexes when running tests

### DIFF
--- a/vars/govuk.groovy
+++ b/vars/govuk.groovy
@@ -192,9 +192,15 @@ def nonDockerBuildTasks(options, jobName, repoName) {
 
   // Prevent a project's tests from running in parallel on the same node
   lock("$jobName-$NODE_NAME-test") {
-    if (hasDatabase()) {
-      stage("Set up the database") {
-          runRakeTask("db:reset")
+    if (hasActiveRecordDatabase()) {
+      stage("Set up the ActiveRecord database") {
+        runRakeTask("db:reset")
+      }
+    }
+    
+    if (hasMongoidDatabase()) {
+      stage("Set up the Mongoid database") {
+        runRakeTask("db:mongoid:create_indexes")
       }
     }
 
@@ -846,8 +852,17 @@ def isRails() {
  *
  * Determined by checking the presence of a `database.yml` file
  */
-def hasDatabase() {
-  sh(script: "test -e config/database.yml", returnStatus: true) == 0
+def hasActiveRecordDatabase() {
+  fileExists(file: "config/database.yml")
+}
+
+/**
+ * Does this project use a Mongoid-style database?
+ *
+ * Determined by checking the presence of a `mongoid.yml` file.
+ */
+def hasMongoidDatabase() {
+  fileExists(file: "config/mongoid.yml")
 }
 
 def validateDockerFileRubyVersion() {


### PR DESCRIPTION
For an application that uses Mongoid, it can sometimes be necessary for the indexes to be there. Specifically, this is the case when using the geospatial modules https://docs.mongodb.com/manual/geospatial-queries/ where there has to be an index to perform these queries.

This is currently making the imminence tests flaky, as it depends on which `ci-agent` machine they run on, since only some of the databases have had those geospatial indexes built.

[Trello Card](https://trello.com/c/MdR10mng/424-fix-flakey-geo-indices-in-imminence-tests)