### PR TITLE
Shallow clone by default

### DIFF
--- a/vars/govuk.groovy
+++ b/vars/govuk.groovy
@@ -332,6 +332,7 @@ def checkoutFromGitHubWithSSH(String repository, Map options = [:]) {
     branch: null,
     changelog: true,
     location: null,
+    shallow: true,
     org: "alphagov",
     poll: true,
     host: "github.com"
@@ -347,7 +348,12 @@ def checkoutFromGitHubWithSSH(String repository, Map options = [:]) {
 
   def extensions = [
     [
-      $class: "CleanCheckout"
+      $class: "CleanCheckout",
+    ],
+    [
+      $class: 'CloneOption',
+      shallow: options.shallow,
+      noTags: options.shallow,
     ]
   ]
 


### PR DESCRIPTION
This takes up less space on the CI agents, and is faster, especially
for larger repositories.