### PR TITLE
Lint all the code by default

### DIFF
--- a/vars/govuk.groovy
+++ b/vars/govuk.groovy
@@ -165,7 +165,7 @@ def nonDockerBuildTasks(options, jobName, repoName) {
 
   if (hasLint()) {
     stage("Lint Ruby") {
-      rubyLinter(options.get('rubyLintDirs', "app lib spec test"), options.get('rubyLintDiff', true))
+      rubyLinter(options.get('rubyLintDirs', "app lib spec test"), options.get('rubyLintDiff', false))
     }
   } else {
     echo "WARNING: You do not have Ruby linting turned on. Please install govuk-lint and enable."
@@ -540,7 +540,7 @@ def setEnvGitCommit() {
 /**
  * Runs the ruby linter. Only lint commits that are not in master.
  */
-def rubyLinter(String dirs = 'app spec lib', boolean lintDiff = true) {
+def rubyLinter(String dirs = 'app spec lib', boolean lintDiff = false) {
   setEnvGitCommit()
   if (!isCurrentCommitOnMaster()) {
     echo 'Running Ruby linter'


### PR DESCRIPTION
Rather than just checking what has changed. This works much better for
updates of the linting rules, as it means that Jenkins will check all
the code, ensuring that any issues are raised.

I've been going around and fixing linting issues in various
repositories, so I think as it's firebreak week, we can have a go at
changing the default (and fixing issues as and when they arise).