### PR TITLE
Use --force-with-lease when updating the release branch

### DIFF
--- a/vars/govuk.groovy
+++ b/vars/govuk.groovy
@@ -703,7 +703,7 @@ def pushTag(String repository, String branch, String tag) {
       // if it does.
       if (releaseBranchExists()) {
         echo "Updating alphagov/${repository} release branch"
-        sh("git push git@github.com:alphagov/${repository}.git HEAD:refs/heads/release")
+        sh("git push git@github.com:alphagov/${repository}.git HEAD:refs/heads/release --force-with-lease")
       }
     }
   } else {


### PR DESCRIPTION
The shallow clone means that Git thinks that the release branch
doesn't join up with the commit it's looking at locally. Therefore,
use --force-with-lease to make the git push work.