### PR TITLE
Don't use --force-with-lease when pushing to release

### DIFF
--- a/vars/govuk.groovy
+++ b/vars/govuk.groovy
@@ -709,7 +709,7 @@ def pushTag(String repository, String branch, String tag) {
       // if it does.
       if (releaseBranchExists()) {
         echo "Updating alphagov/${repository} release branch"
-        sh("git push git@github.com:alphagov/${repository}.git HEAD:refs/heads/release --force-with-lease")
+        sh("git push git@github.com:alphagov/${repository}.git HEAD:refs/heads/release --force")
       }
     }
   } else {


### PR DESCRIPTION
I don't know why, but it doesn't seem to work. Git thinks it has stale
info, when it doesn't. So just use plain --force instead.