### PR TITLE
Don't shallow clone when building master

### DIFF
--- a/vars/govuk.groovy
+++ b/vars/govuk.groovy
@@ -332,7 +332,7 @@ def checkoutFromGitHubWithSSH(String repository, Map options = [:]) {
     branch: null,
     changelog: true,
     location: null,
-    shallow: true,
+    shallow: env.BRANCH_NAME != "master",
     org: "alphagov",
     poll: true,
     host: "github.com"


### PR DESCRIPTION
This seems to cause issues when updating the release branch, and
possibly mirroring.