### PR TITLE
Revert changes to clone / push

### DIFF
--- a/vars/govuk.groovy
+++ b/vars/govuk.groovy
@@ -709,7 +709,7 @@ def pushTag(String repository, String branch, String tag) {
       // if it does.
       if (releaseBranchExists()) {
         echo "Updating alphagov/${repository} release branch"
-        sh("git push git@github.com:alphagov/${repository}.git HEAD:refs/heads/release --force-with-lease")
+        sh("git push git@github.com:alphagov/${repository}.git HEAD:refs/heads/release")
       }
     }
   } else {

--- a/vars/govuk.groovy
+++ b/vars/govuk.groovy
@@ -332,7 +332,7 @@ def checkoutFromGitHubWithSSH(String repository, Map options = [:]) {
     branch: null,
     changelog: true,
     location: null,
-    shallow: env.BRANCH_NAME != "master",
+    shallow: true,
     org: "alphagov",
     poll: true,
     host: "github.com"

--- a/vars/govuk.groovy
+++ b/vars/govuk.groovy
@@ -332,7 +332,6 @@ def checkoutFromGitHubWithSSH(String repository, Map options = [:]) {
     branch: null,
     changelog: true,
     location: null,
-    shallow: true,
     org: "alphagov",
     poll: true,
     host: "github.com"
@@ -348,12 +347,7 @@ def checkoutFromGitHubWithSSH(String repository, Map options = [:]) {
 
   def extensions = [
     [
-      $class: "CleanCheckout",
-    ],
-    [
-      $class: 'CloneOption',
-      shallow: options.shallow,
-      noTags: options.shallow,
+      $class: "CleanCheckout"
     ]
   ]
 


### PR DESCRIPTION
This reverts https://github.com/alphagov/govuk-jenkinslib/pull/34 https://github.com/alphagov/govuk-jenkinslib/pull/37 and https://github.com/alphagov/govuk-jenkinslib/pull/39, because I think it's causing master to fail on Signon:

https://ci.integration.publishing.service.gov.uk/job/signon/job/master/1102/console