### PR TITLE
Use shallow clones for building non-master branches

### DIFF
--- a/vars/govuk.groovy
+++ b/vars/govuk.groovy
@@ -332,6 +332,7 @@ def checkoutFromGitHubWithSSH(String repository, Map options = [:]) {
     branch: null,
     changelog: true,
     location: null,
+    shallow: env.BRANCH_NAME != "master",
     org: "alphagov",
     poll: true,
     host: "github.com"
@@ -347,7 +348,12 @@ def checkoutFromGitHubWithSSH(String repository, Map options = [:]) {
 
   def extensions = [
     [
-      $class: "CleanCheckout"
+      $class: "CleanCheckout",
+    ],
+    [
+      $class: 'CloneOption',
+      shallow: options.shallow,
+      noTags: options.shallow,
     ]
   ]
 


### PR DESCRIPTION
This takes up less space on the CI agents, and is faster, especially
for larger repositories. Shallow cloning for the master branch builds
causes issues with updating the release branch, so avoid this for
builds of the master branch.

This reverts commits 9b3a80287d2f48d600db3ea89d2a7a3c6da845ac,
7414b838e3393e373db70e6a2c230a74e66564db,
8a3cb08382524c660272e1ea04d62a00fb4cf087.