### PR TITLE
Workaround merge issues with shallow clones

### DIFF
--- a/vars/govuk.groovy
+++ b/vars/govuk.groovy
@@ -453,6 +453,12 @@ def mergeMasterBranch() {
   } else {
     echo "Current commit is not on master, so attempting merge of master " +
       "branch before proceeding with build"
+
+    sshagent(['govuk-ci-ssh-key']) {
+      sh("git fetch --no-tags --depth=30 origin " +
+         "+refs/heads/master:refs/remotes/origin/master " +
+         "refs/heads/${env.BRANCH_NAME}:refs/remotes/origin/${env.BRANCH_NAME}")
+    }
     sh('git merge --no-commit origin/master || git merge --abort')
   }
 }


### PR DESCRIPTION
There's some value in merging the master branch, as this is a slightly
more rigorous test of the state that would result from merging the
branch. There's also value in only doing a shallow clone, as this
mitigates the space and time issues of constantly growing Git
repositories.

Currently, merging master is failing as Git doesn't have enough
information to perform the merge. I think if a newer version of Git
was in use, it would even refuse to attempt the merge.

Therefore, to try and get the best of both worlds, fetch more commits,
so that merging master works for most Pull Requests.