### PR TITLE
Report linting tasks separately

### DIFF
--- a/vars/govuk.groovy
+++ b/vars/govuk.groovy
@@ -165,7 +165,7 @@ def nonDockerBuildTasks(options, jobName, repoName) {
 
   if (hasLint()) {
     stage("Lint Ruby") {
-      rubyLinter(options.get('rubyLintDirs', "app lib spec test"), options.get('rubyLintDiff', true))
+      rubyLinter(repoName, options.get('rubyLintDirs', "app lib spec test"), options.get('rubyLintDiff', true))
     }
   } else {
     echo "WARNING: You do not have Ruby linting turned on. Please install govuk-lint and enable."
@@ -173,7 +173,7 @@ def nonDockerBuildTasks(options, jobName, repoName) {
 
   if (hasAssets() && hasLint() && options.sassLint != false) {
     stage("Lint SASS") {
-      sassLinter()
+      sassLinter(repoName)
     }
   } else {
     echo "WARNING: You do not have SASS linting turned on. Please install govuk-lint and enable."
@@ -552,19 +552,26 @@ def setEnvGitCommit() {
 /**
  * Runs the ruby linter. Only lint commits that are not in master.
  */
-def rubyLinter(String dirs = 'app spec lib', boolean lintDiff = true) {
+def rubyLinter(String repoName, String dirs = 'app spec lib', boolean lintDiff = true) {
   setEnvGitCommit()
+
   if (!isCurrentCommitOnMaster()) {
     echo 'Running Ruby linter'
 
     withStatsdTiming("ruby_lint") {
-      sh("bundle exec govuk-lint-ruby \
+      def lintIsOkay = runsSuccessfully("bundle exec govuk-lint-ruby \
          --parallel \
          ${lintDiff ? '--diff --cached' : ''} \
          --format html --out rubocop-${GIT_COMMIT}.html \
          --format clang \
          ${dirs}"
       )
+
+      if (lintIsOkay) {
+        setBuildStatus("ruby-linter", getFullCommitHash(), "No Ruby linting issues found", "SUCCESS", repoName)
+      } else {
+        setBuildStatus("ruby-linter", getFullCommitHash(), "Ruby linter found issues", "FAILURE", repoName)
+      }
     }
   }
 }
@@ -572,11 +579,22 @@ def rubyLinter(String dirs = 'app spec lib', boolean lintDiff = true) {
 /**
  * Runs the SASS linter
  */
-def sassLinter(String dirs = 'app/assets/stylesheets') {
+def sassLinter(String dirs = 'app/assets/stylesheets', String repoName) {
   echo 'Running SASS linter'
   withStatsdTiming("sass_lint") {
-    sh("bundle exec govuk-lint-sass ${dirs}")
+    if (runsSuccessfully("bundle exec govuk-lint-sass ${dirs}")) {
+      setBuildStatus("css-linter", getFullCommitHash(), "No CSS linting issues found", "SUCCESS", repoName)
+    } else {
+      setBuildStatus("css-linter", getFullCommitHash(), "CSS linter found issues", "FAILURE", repoName)
+    }
   }
+}
+
+/**
+ * Runs a command and returns true it ran successfully
+ */
+def runsSuccessfully(command) {
+  return sh(script: command, returnStatus: true) == 0
 }
 
 /**


### PR DESCRIPTION
I seem to find myself often in a situation where I open a PR without running the tests locally. Inevitably, my branch fails on CI because of a linting violation. I then go back to fix the linting issues and force-push. This time, the linter passes but a test fails, which requires me to do the same dance again.

This commit changes our build script to report the CSS and Ruby linter runs separately:

<img width="804" alt="screen shot 2019-02-20 at 15 00 32" src="https://user-images.githubusercontent.com/233676/53100971-b8f80b80-3520-11e9-8366-b9b48ed044a9.png">
 
This means that 1) you can immediately see why your branch is failing, 2) you'll be able to see both linting and test runs at the same time, because the job doesn't stop after encountering a linter error. This should especially help with large test suites.

A downside is that _technically_ you could merge a PR with linter violations, because we haven't made the css-lint and ruby-lint checks mandatory (I'm not a 100% sure [how we'd do that in govuk-saas-config](https://github.com/alphagov/govuk-saas-config/blob/5bafddbc4e46cefbefb54c4b52c1e5bc989e2adf/github/lib/configure_repo.rb#L88-L98)). I'm relying on the fact that developers on GOV.UK are a honourable bunch who would rather quit than merge in a PR with a failed CI run.

I think there will be a [number of Jenkinsfiles](https://github.com/search?p=1&q=org%3Aalphagov+rubyLinter&type=Code) that call the `rubyLinter` directly, which should be updated to include the `repoName` argument.

Tested on https://github.com/alphagov/government-frontend/pull/1251.