### PR TITLE
Revert "Remove unused code"

### DIFF
--- a/vars/govuk.groovy
+++ b/vars/govuk.groovy
@@ -17,6 +17,11 @@ def buildProject(Map options = [:]) {
       description: 'Identifies whether this build is being triggered to test a change to the content schemas'
     ),
     booleanParam(
+      name: 'PUSH_TO_GCR',
+      defaultValue: false,
+      description: '--TESTING ONLY-- Whether to push the docker image to Google Container Registry.'
+    ),
+    booleanParam(
       name: 'RUN_DOCKER_TASKS',
       defaultValue: true,
       description: 'Whether to build and push the Docker image, if a Dockerfile exists.'
@@ -272,6 +277,10 @@ def dockerBuildTasks(options, jobName) {
   if (!(env.BRANCH_NAME ==~ /^deployed-to/)) {
     stage("Push Docker image") {
       pushDockerImage(jobName, env.BRANCH_NAME)
+
+      if (params.PUSH_TO_GCR) {
+        pushDockerImageToGCR(jobName, env.BRANCH_NAME)
+      }
     }
   }
 }
@@ -935,6 +944,25 @@ def pushDockerImage(imageName, tagName, asTag = null) {
   }
 }
 
+def pushDockerImageToGCR(imageName, tagName) {
+  tagName = safeDockerTag(tagName)
+  gcrName = "gcr.io/govuk-test/${imageName}"
+  docker.build(gcrName)
+
+  withCredentials([file(credentialsId: 'govuk-test', variable: 'GCR_CRED_FILE')]) {
+    // We don't want to interpolate this command as GCR_CRED_FILE is set as an
+    // environment variable in bash.
+    command = 'gcloud auth activate-service-account --key-file "$GCR_CRED_FILE"'
+    sh command
+    // We do want to interpolate this command to get the value of gcrName
+    command = "gcloud docker -- push ${gcrName}"
+    sh command
+    // Add the tag, again this needs to be interpolated
+    command = "gcloud container images add-tag ${gcrName} ${gcrName}:${tagName}"
+    sh command
+  }
+}
+
 def safeDockerTag(tagName) {
   // A valid tag is:
   //   ascii, uppercase, lowercase, digits, underscore, dash, period,
@@ -1042,6 +1070,14 @@ def shellcheck(setFiles = [], setExcludes = []) {
     sh("shellcheck -e ${ignoreCodes.join(",")} ${setFiles.join(" ")}")
   }
 
+}
+
+/*
+ * This is a method to test that the external library loading
+ * works as expect
+ */
+def pipelineTest() {
+  sh("echo 'If you see this I am working as expected'")
 }
 
 return this;


### PR DESCRIPTION
Reverts alphagov/govuk-jenkinslib#45. Turns out `govuk.pipelineTest` is actually used - by the tests for this repo.