### PR TITLE
Precompile assets before testing

### DIFF
--- a/vars/govuk.groovy
+++ b/vars/govuk.groovy
@@ -204,6 +204,12 @@ def nonDockerBuildTasks(options, jobName, repoName) {
       }
     }
 
+    if (hasAssets() && !params.IS_SCHEMA_TEST) {
+      stage("Precompile assets") {
+        precompileAssets()
+      }
+    }
+
     if (options.overrideTestTask) {
       echo "Running custom test task"
       options.overrideTestTask.call()
@@ -260,12 +266,6 @@ def nonDockerBuildTasks(options, jobName, repoName) {
   if (options.afterTest) {
     echo "Running post-test tasks"
     options.afterTest.call()
-  }
-
-  if (hasAssets() && !params.IS_SCHEMA_TEST) {
-    stage("Precompile assets") {
-      precompileAssets()
-    }
   }
 }
 
@@ -596,7 +596,7 @@ def postgres96Linter(String base = 'master', String file = 'db/schema.rb') {
 def precompileAssets() {
   echo 'Precompiling the assets'
   withStatsdTiming("assets_precompile") {
-    sh('RAILS_ENV=production SECRET_KEY_BASE=1 GOVUK_WEBSITE_ROOT=http://www.test.gov.uk GOVUK_APP_DOMAIN=test.gov.uk GOVUK_APP_DOMAIN_EXTERNAL=test.gov.uk GOVUK_ASSET_ROOT=https://static.test.gov.uk GOVUK_ASSET_HOST=https://static.test.gov.uk bundle exec rake assets:clobber assets:precompile')
+    sh('RAILS_ENV=test SECRET_KEY_BASE=1 GOVUK_WEBSITE_ROOT=http://www.test.gov.uk GOVUK_APP_DOMAIN=test.gov.uk GOVUK_APP_DOMAIN_EXTERNAL=test.gov.uk GOVUK_ASSET_ROOT=https://static.test.gov.uk GOVUK_ASSET_HOST=https://static.test.gov.uk bundle exec rake assets:clobber assets:precompile')
   }
 }
 


### PR DESCRIPTION
Move the precompile asset step before the testing step. Also set the
`RAILS_ENV=test` for asset precompilation.

In some of our applications such as government-frontend, we rely on
Capybara and Selenium to do some front end testing. When Capybara kicks
off, it tries to precompile assets if they aren't already precompiled.
This can take quite a while and sometimes causes `Net::ReadTimeout`
errors. If we instead precompile assets before Capybara runs, it will
use the precompiled assets and skip trying to precompile them. This
means we don't spend time during the first request waiting for
precompilation and we are less likely to hit the timeout.

Changing `RAILS_ENV` from `production` to `test` so that during testing
we use the precompiled assets. This shouldn't affect behaviour because
the intent of the asset precompilation step is test for syntax errors
in the CSS which will still happen.

Supersedes https://github.com/alphagov/govuk-jenkinslib/pull/49

[Trello](https://trello.com/c/AlYnvTTI/804-precompile-assets-during-tests-on-ci-for-government-frontend)