### PR TITLE
Precompile assets on schema tests too

### DIFF
--- a/vars/govuk.groovy
+++ b/vars/govuk.groovy
@@ -204,7 +204,7 @@ def nonDockerBuildTasks(options, jobName, repoName) {
       }
     }
 
-    if (hasAssets() && !params.IS_SCHEMA_TEST) {
+    if (hasAssets()) {
       stage("Precompile assets") {
         precompileAssets()
       }


### PR DESCRIPTION
We're seeing the same timeout issues on schema tests as we did on standard branch tests.  Hopefully running precompile assets will fix this.

Example: https://ci.integration.publishing.service.gov.uk/job/government-frontend/job/deployed-to-production/124/console

> Net::ReadTimeout:         Net::ReadTimeout: Net::ReadTimeout with #<TCPSocket:(closed)>
            test/test_helper.rb:197:in `visit_with_cachebust'
            test/test_helper.rb:152:in `block in setup_and_visit_content_item'
            test/test_helper.rb:150:in `tap'
            test/test_helper.rb:150:in `setup_and_visit_content_item'
            test/integration/document_collection_test.rb:5:in `block in <class:DocumentCollectionTest>'