### PR TITLE
Remove push to Gitlab mirror

### DIFF
--- a/vars/govuk.groovy
+++ b/vars/govuk.groovy
@@ -115,13 +115,6 @@ def buildProject(Map options = [:]) {
           pushTag(repoName, env.BRANCH_NAME, 'release_' + env.BUILD_NUMBER)
         }
 
-        stage("Push to Gitlab") {
-          try {
-            pushToMirror(repoName, env.BRANCH_NAME, 'release_' + env.BUILD_NUMBER)
-          } catch (e) {
-          }
-        }
-
         if (hasDockerfile() && params.RUN_DOCKER_TASKS) {
           stage("Tag Docker image") {
             dockerTagMasterBranch(jobName, env.BRANCH_NAME, env.BUILD_NUMBER)
@@ -720,20 +713,6 @@ def pushTag(String repository, String branch, String tag) {
     }
   } else {
     echo 'No tagging on branch'
-  }
-}
-
-def pushToMirror(String repository, String branch, String tag) {
-  if (branch == 'master'){
-    withCredentials([string(credentialsId: 'gitlab-govuk-ci', variable: 'TOKEN')]) {
-      mirrorUrl = "https://govuk-ci:$TOKEN@gitlab.com/govuk/${repository}.git"
-
-      echo 'Pushing master branch to Gitlab'
-      sh("git push ${mirrorUrl} HEAD:refs/heads/${branch} --force")
-
-      echo 'Pushing tag to Gitlab'
-      sh("git push ${mirrorUrl} ${tag}")
-    }
   }
 }
 


### PR DESCRIPTION
The repo mirror has moved from Gitlab to AWS CodeCommit.  Code was still being pushed to Gitlab as part of the CI build.