### PR TITLE
Conditionally control deploying to integration

### DIFF
--- a/vars/govuk.groovy
+++ b/vars/govuk.groovy
@@ -121,8 +121,10 @@ def buildProject(Map options = [:]) {
           }
         }
 
-        stage("Deploy to integration") {
-          deployIntegration(jobName, env.BRANCH_NAME, "release_${env.BUILD_NUMBER}", 'deploy')
+        if (!options.skipDeployToIntegration) {
+          stage("Deploy to integration") {
+            deployIntegration(jobName, env.BRANCH_NAME, "release_${env.BUILD_NUMBER}", 'deploy')
+          }
         }
       }
     }


### PR DESCRIPTION
The build of `govuk-saas-config` is breaking.

I believe it's because we try to call the downstream job `integration-app-deploy` with the `application`argument being `govuk-saas-config`. 

However the downstream job expects the application name to be one defined in
https://github.com/alphagov/govuk-puppet/blob/a6ffb49be5895e1ef3f6c849384f09d1f7073e69/hieradata/common.yaml#L121 which does not include `govuk-saas-config`

We don't need this step for `govuk-saas-config` because it isn't a deployable application.

Add a condition around the "Deploy to integration" stage controlled by an option that we can pass in to `buildProject`. It should default to allow builds to continue as normal unless the option is set.