### PR TITLE
Only test against used ruby versions

### DIFF
--- a/vars/govuk.groovy
+++ b/vars/govuk.groovy
@@ -659,7 +659,7 @@ def runTests(String test_task = 'default') {
  * addition to the versions currently supported by all GOV.UK applications
  */
 def testGemWithAllRubies(extraRubyVersions = []) {
-  def rubyVersions = ["2.4", "2.5", "2.6"]
+  def rubyVersions = ["2.6"]
 
   rubyVersions.addAll(extraRubyVersions)
 


### PR DESCRIPTION
We only have ruby 2.6.3 installed on our machines. I'm not aware of any external consumers of our gems

This should save about 3 minutes from a CI run of govuk_publishing_components