### PR TITLE
Remove diff linting functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,11 +72,8 @@ beforeTest | A closure containing commands to run before the test stage, such as
 brakeman | Whether or not to run the Brakeman security scanner | `true` if a Rails app, otherwise `false`
 extraParameters | Provide details here of any extra parameters that can be used to configure this build.  See: https://jenkins.io/doc/pipeline/steps/workflow-multibranch/#code-properties-code-set-job-properties for details on the format and structure of these extra parameters. |
 extraRubyVersions | Ruby versions to run the tests against in addition to the versions currently supported by all GOV.UK applications. Only applies to gems because they may be used in projects with different Ruby versions. | `[]`
-newStyleDockerTags | Tag docker images with timestamp and git SHA rather than the default of the build number repoName Provide this if the Github Repo name for the app is different to the jenkins job name. | `false`
 overrideTestTask | A closure containing commands to run to test the project. This will run instead of the default `bundle exec rake` |
 postgres96Lint | Whether or not to forbid newer postgres features | `true`
 publishingE2ETests | Whether or not to run the Publishing end-to-end tests. | `false`
-rubyLintDiff | Whether or not to pass the `--diff` option to `govuk-lint-ruby` | `true`
-rubyLintRails | Whether or not to pass the `--rails` option to `govuk-lint-ruby` | `false`
 sassLint | Whether or not to run the SASS linter | `true`
 skipDeployToIntegration | Whether or not to skip the "Deploy to integration" stage | `false`

--- a/vars/govuk.groovy
+++ b/vars/govuk.groovy
@@ -160,7 +160,7 @@ def nonDockerBuildTasks(options, jobName, repoName) {
 
   if (hasLint()) {
     stage("Lint Ruby") {
-      rubyLinter(options.get('rubyLintDirs', "app lib spec test"), options.get('rubyLintDiff', true))
+      rubyLinter(options.get('rubyLintDirs', "app lib spec test"))
     }
   } else {
     echo "WARNING: You do not have Ruby linting turned on. Please install govuk-lint and enable."
@@ -547,7 +547,7 @@ def setEnvGitCommit() {
 /**
  * Runs the ruby linter. Only lint commits that are not in master.
  */
-def rubyLinter(String dirs = 'app spec lib', boolean lintDiff = true) {
+def rubyLinter(String dirs = 'app spec lib') {
   setEnvGitCommit()
   if (!isCurrentCommitOnMaster()) {
     echo 'Running Ruby linter'
@@ -555,7 +555,6 @@ def rubyLinter(String dirs = 'app spec lib', boolean lintDiff = true) {
     withStatsdTiming("ruby_lint") {
       sh("bundle exec govuk-lint-ruby \
          --parallel \
-         ${lintDiff ? '--diff --cached' : ''} \
          --format html --out rubocop-${GIT_COMMIT}.html \
          --format clang \
          ${dirs}"


### PR DESCRIPTION
This removes the option that only the diff of Ruby code can be linted.

We started the process to stop only linting diffs back in May 2018 with #9 when the option to turn off diffing was first created. An attempt was made to make this the default was done in #35 however this was reverted in #36 since it broke quite a few repos.

Nearly a year later we're more confident as the roll out of govuk-lint 4.0 alphagov/govuk-lint#126 has meant a significant amount of repos are now no longer diff linting and have meet current lint requirements.

There will no doubt still be a few things that fail due to this - I'm sorry - but this will help us move towards the world where we can consider adopting the outcome of https://github.com/alphagov/govuk-rfcs/blob/master/rfc-100-linting.md

I decided rather than to make this an option we could just turn it off. For apps that fail because of this there is an expectation that linting is fixed rather than allowing them to use a deprecated behaviour. If this causes people misery the operation can return but defaulted to false.

Note: talking to @benthorner and @thomasleese we're likely to get lintdiff off in smart-answers, search-api and transition before this is merged.