### PR TITLE
Add ability to specify custom Gem name

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ beforeTest | A closure containing commands to run before the test stage, such as
 brakeman | Whether or not to run the Brakeman security scanner | `true` if a Rails app, otherwise `false`
 extraParameters | Provide details here of any extra parameters that can be used to configure this build.  See: https://jenkins.io/doc/pipeline/steps/workflow-multibranch/#code-properties-code-set-job-properties for details on the format and structure of these extra parameters. |
 extraRubyVersions | Ruby versions to run the tests against in addition to the versions currently supported by all GOV.UK applications. Only applies to gems because they may be used in projects with different Ruby versions. | `[]`
+gemName | If publishing a Rubygem, you can specify the Gem name. | Repository name
 overrideTestTask | A closure containing commands to run to test the project. This will run instead of the default `bundle exec rake` |
 postgres96Lint | Whether or not to forbid newer postgres features | `true`
 publishingE2ETests | Whether or not to run the Publishing end-to-end tests. | `false`


### PR DESCRIPTION
This allows a custom Gam name to be specified, otherwise it defaults to the previous behaviour of using the repoName.

```groovy
node {
  govuk.buildProject(
    gemName: 'custom-gem-name'
  )
}
```