### PR TITLE
Fix missing quotes on end of warning string

### DIFF
--- a/vars/govuk.groovy
+++ b/vars/govuk.groovy
@@ -187,7 +187,7 @@ def nonDockerBuildTasks(options, jobName, repoName) {
       lintSCSS()
     }
   } else {
-    echo "WARNING: You do not have scss-lint installed.
+    echo "WARNING: You do not have scss-lint installed."
   }
 
   if (options.postgres96Lint != false) {


### PR DESCRIPTION
CI is failing because of a syntax error - a missing quote at the end of a string.