### PR TITLE
lintRuby: Stop setting dirs to lint

### DIFF
--- a/vars/govuk.groovy
+++ b/vars/govuk.groovy
@@ -564,7 +564,7 @@ def setEnvGitCommit() {
 /**
  * Runs RuboCop. Only lint commits that are not in master.
  */
-def lintRuby(String dirs = 'app spec lib') {
+def lintRuby {
   setEnvGitCommit()
   if (!isCurrentCommitOnMaster()) {
     echo 'Running RuboCop'
@@ -573,8 +573,7 @@ def lintRuby(String dirs = 'app spec lib') {
       sh("bundle exec rubocop \
          --parallel \
          --format html --out rubocop-${GIT_COMMIT}.html \
-         --format clang \
-         ${dirs}"
+         --format clang"
       )
     }
   }


### PR DESCRIPTION
- This should be handled by the gem that sets the rest of the linter
  config - `rubocop-govuk` - rather than the CI system.
- Leaving it to the CI system to decide which directories to lint is
  confusing for developers - it's so far away from their day-to-day.
- Also, the setting was overrideable with an option specified in an
  app's Jenkinsfile.
- The `rubocop-govuk` gem, as of v3.0.0, will set dirs to _not_ lint
  specifically in .rubocop.yml which is clearer to people working on the
  apps.