### PR TITLE
lintRuby: In Groovy, parentheses are significant

### DIFF
--- a/vars/govuk.groovy
+++ b/vars/govuk.groovy
@@ -564,7 +564,7 @@ def setEnvGitCommit() {
 /**
  * Runs RuboCop. Only lint commits that are not in master.
  */
-def lintRuby {
+def lintRuby() {
   setEnvGitCommit()
   if (!isCurrentCommitOnMaster()) {
     echo 'Running RuboCop'


### PR DESCRIPTION
Before:

```
/var/lib/jenkins/jobs/email-alert-monitoring/branches/remove-lin.emtbgpj0m4.-lint-call/builds/1/libs/govuk/vars/govuk.groovy: 567: unexpected token: lintRuby @ line 567, column 5.
   def lintRuby {
       ^
```