### PR TITLE
lintRuby: Don't pass arguments when invoking the linter

### DIFF
--- a/vars/govuk.groovy
+++ b/vars/govuk.groovy
@@ -168,7 +168,7 @@ def nonDockerBuildTasks(options, jobName, repoName) {
 
   if (hasRubocop()) {
     stage("Lint Ruby") {
-      lintRuby(options.get('rubyLintDirs', "app lib spec test"))
+      lintRuby()
     }
   } else {
     echo "WARNING: You do not have Rubocop installed."


### PR DESCRIPTION
Before:

```
java.lang.NoSuchMethodError: No such DSL method 'lintRuby' found among steps [VersionNumber, ansiColor, archive, bat, build, catchError, ...........]
```