### PR TITLE
Allow repos to limit Jenkins to doing releases

### DIFF
--- a/vars/govuk.groovy
+++ b/vars/govuk.groovy
@@ -109,7 +109,9 @@ def buildProject(Map options = [:]) {
         "build" : { nonDockerBuildTasks(options, jobName, repoName) },
         "docker" : { dockerBuildTasks(options, jobName) }
       )
-    } else {
+    } else if (env.BRANCH_NAME == "master") {
+      nonDockerBuildTasks(options, jobName, repoName)
+    } else if (!options.migratedToGithubActions) {
       nonDockerBuildTasks(options, jobName, repoName)
     }
 


### PR DESCRIPTION
Previously we added GitHub Actions for some of our repos, but this
creates duplicated work, since Jenkins still runs all the tests,
linting, etc. This adds a new flag so that repos can restrict Jenkins
to only performing release-related tasks: 'git tag' and 'gem push'.