### PR TITLE
Remove GOVUK_ASSET_HOST

### DIFF
--- a/vars/govuk.groovy
+++ b/vars/govuk.groovy
@@ -603,7 +603,7 @@ def postgres96Linter(String base = 'master', String file = 'db/schema.rb') {
  */
 def precompileAssets() {
   echo 'Precompiling the assets'
-  sh('RAILS_ENV=test SECRET_KEY_BASE=1 GOVUK_WEBSITE_ROOT=http://www.test.gov.uk GOVUK_APP_DOMAIN=test.gov.uk GOVUK_APP_DOMAIN_EXTERNAL=test.gov.uk GOVUK_ASSET_ROOT=https://static.test.gov.uk GOVUK_ASSET_HOST=https://static.test.gov.uk bundle exec rake assets:clobber assets:precompile')
+  sh('RAILS_ENV=test SECRET_KEY_BASE=1 GOVUK_WEBSITE_ROOT=http://www.test.gov.uk GOVUK_APP_DOMAIN=test.gov.uk GOVUK_APP_DOMAIN_EXTERNAL=test.gov.uk GOVUK_ASSET_ROOT=https://static.test.gov.uk bundle exec rake assets:clobber assets:precompile')
 }
 
 /**


### PR DESCRIPTION
Trello: https://trello.com/c/oNEtjIVp/99-serve-static-assets-from-www-hostname

This environment variable is no longer used in apps.