### PR TITLE
Remove lintRuby build step

### DIFF
--- a/vars/govuk.groovy
+++ b/vars/govuk.groovy
@@ -166,14 +166,6 @@ def nonDockerBuildTasks(options, jobName, repoName) {
     }
   }
 
-  if (hasRubocop()) {
-    stage("Lint Ruby") {
-      lintRuby()
-    }
-  } else {
-    echo "WARNING: You do not have Rubocop installed."
-  }
-
   if (hasAssets() && hasSCSSLint() && options.sassLint != false) {
     stage("Lint SCSS") {
       lintSCSS()
@@ -555,22 +547,6 @@ def getGitCommit() {
  */
 def setEnvGitCommit() {
   env.GIT_COMMIT = getGitCommit()
-}
-
-/**
- * Runs RuboCop. Only lint commits that are not in master.
- */
-def lintRuby() {
-  setEnvGitCommit()
-  if (!isCurrentCommitOnMaster()) {
-    echo 'Running RuboCop'
-
-    sh("bundle exec rubocop \
-       --parallel \
-       --format html --out rubocop-${GIT_COMMIT}.html \
-       --format clang"
-    )
-  }
 }
 
 /**


### PR DESCRIPTION
This is now done as part of the default rake task for everything.

---

[Trello card](https://trello.com/c/5Gob6WUL/147-for-everyone-ensure-that-rubocop-runs-as-part-of-bundle-exec-rake-as-one-of-the-default-tasks)