### PR TITLE
do not update github after jenkins tests in AWS CI

### DIFF
--- a/vars/govuk.groovy
+++ b/vars/govuk.groovy
@@ -113,7 +113,11 @@ def buildProject(Map options = [:]) {
       nonDockerBuildTasks(options, jobName, repoName)
     }
 
-    if (env.BRANCH_NAME == "master" && !params.IS_SCHEMA_TEST) {
+    /**
+    * we test that there is no AWS_DEFAULT_REGION env variable so that AWS CI can be tested
+    * without affecting external systems such as github tags, docker or deployed.
+    */
+    if (env.BRANCH_NAME == "master" && !params.IS_SCHEMA_TEST && env.AWS_DEFAULT_REGION == null) {
       if (isGem()) {
         stage("Publish Gem to Rubygems") {
           publishGem(gemName, repoName, env.BRANCH_NAME)
@@ -940,14 +944,20 @@ def uploadArtefactToS3(artefact_path, s3_path){
  * @param repoName The alphagov repository
  */
 def setBuildStatus(jobName, commit, message, state, repoName) {
-  step([
-      $class: "GitHubCommitStatusSetter",
-      commitShaSource: [$class: "ManuallyEnteredShaSource", sha: commit],
-      reposSource: [$class: "ManuallyEnteredRepositorySource", url: "https://github.com/alphagov/${repoName}"],
-      contextSource: [$class: "ManuallyEnteredCommitContextSource", context: "continuous-integration/jenkins/${jobName}"],
-      errorHandlers: [[$class: "ChangingBuildStatusErrorHandler", result: "UNSTABLE"]],
-      statusResultSource: [ $class: "ConditionalStatusResultSource", results: [[$class: "AnyBuildResult", message: message, state: state]] ]
-  ]);
+  /**
+  * we test that there is no AWS_DEFAULT_REGION env variable so that AWS CI can be tested
+  * without affecting external systems such as github tags, docker or deployed.
+  */
+  if (env.AWS_DEFAULT_REGION == null) {
+    step([
+        $class: "GitHubCommitStatusSetter",
+        commitShaSource: [$class: "ManuallyEnteredShaSource", sha: commit],
+        reposSource: [$class: "ManuallyEnteredRepositorySource", url: "https://github.com/alphagov/${repoName}"],
+        contextSource: [$class: "ManuallyEnteredCommitContextSource", context: "continuous-integration/jenkins/${jobName}"],
+        errorHandlers: [[$class: "ChangingBuildStatusErrorHandler", result: "UNSTABLE"]],
+        statusResultSource: [ $class: "ConditionalStatusResultSource", results: [[$class: "AnyBuildResult", message: message, state: state]] ]
+    ]);
+  }
 }
 
 def runPublishingE2ETests(appCommitishName, testBranch, repo, testCommand = "test") {


### PR DESCRIPTION
We want to test the new AWS CI by running it in parallel with the current Carrenza CI. To avoid any confusion or blockage, we do not want AWS CI to report the status of the build to github as only the Carrenza CI build result is considered valid for now until we can ascertain that AWS CI is working properly.