### PR TITLE
Test Ruby gems with 2.7

### DIFF
--- a/vars/govuk.groovy
+++ b/vars/govuk.groovy
@@ -645,7 +645,7 @@ def runTests(String test_task = 'default') {
  * addition to the versions currently supported by all GOV.UK applications
  */
 def testGemWithAllRubies(extraRubyVersions = []) {
-  def rubyVersions = ["2.6"]
+  def rubyVersions = ["2.6", "2.7"]
 
   rubyVersions.addAll(extraRubyVersions)
 


### PR DESCRIPTION
We're starting to run our apps with 2.7 so we should also start testing our Gems with that version too.