### PR TITLE
Run tests on a clean mongo database

### DIFF
--- a/vars/govuk.groovy
+++ b/vars/govuk.groovy
@@ -195,7 +195,8 @@ def nonDockerBuildTasks(options, jobName, repoName) {
 
     if (hasMongoidDatabase()) {
       stage("Set up the Mongoid database") {
-        runRakeTask("db:mongoid:create_indexes")
+        runRakeTask("db:drop")
+        runRakeTask("db:setup")
       }
     }
 


### PR DESCRIPTION
`db:drop`:
- drops all the collections in the current env

https://github.com/mongodb/mongoid/blob/71abc955b20f05494947c38a11cc520ac712980f/lib/mongoid/railties/database.rake#L7-L10

`db:setup`:
- creates the database
- creates the indices
- seeds the db

https://github.com/mongodb/mongoid/blob/71abc955b20f05494947c38a11cc520ac712980f/lib/mongoid/railties/database.rake#L26-L29

At present, we rerun on an existing db with old state. This makes for confusing
errors.