### PR TITLE
Remove scss-lint

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,18 +35,6 @@ For gems: if the version has changed, the latest version will be released to rub
 
 ## Exceptions
 
-If you use `govuk-lint` but aren't linting your SASS yet (you should), you can
-disable linting:
-
-```groovy
-#!/usr/bin/env groovy
-
-library("govuk")
-
-node {
-  govuk.buildProject(sassLint: false)
-}
-```
 
 If you need to run tests using a command other than the default rake task
 you can do this by specifying the `overrideTestTask` option:
@@ -76,5 +64,4 @@ gemName | If publishing a Rubygem, you can specify the Gem name. | Repository na
 overrideTestTask | A closure containing commands to run to test the project. This will run instead of the default `bundle exec rake` |
 postgres96Lint | Whether or not to forbid newer postgres features | `true`
 publishingE2ETests | Whether or not to run the Publishing end-to-end tests. | `false`
-sassLint | Whether or not to run the SASS linter | `true`
 skipDeployToIntegration | Whether or not to skip the "Deploy to integration" stage | `false`

--- a/vars/govuk.groovy
+++ b/vars/govuk.groovy
@@ -166,14 +166,6 @@ def nonDockerBuildTasks(options, jobName, repoName) {
     }
   }
 
-  if (hasAssets() && hasSCSSLint() && options.sassLint != false) {
-    stage("Lint SCSS") {
-      lintSCSS()
-    }
-  } else {
-    echo "WARNING: You do not have scss-lint installed."
-  }
-
   if (options.postgres96Lint != false) {
     stage("Check for Postgres 9.6 features") {
       postgres96Linter()
@@ -551,22 +543,6 @@ def setEnvGitCommit() {
 }
 
 /**
- * Runs govuk-lint-sass (deprecated)
- */
-def sassLinter(String dirs = 'app/assets/stylesheets') {
-  echo 'Running SASS linter'
-  sh("bundle exec govuk-lint-sass ${dirs}")
-}
-
-/**
- * Runs scss-lint
- */
-def lintSCSS(String dirs = 'app/assets/stylesheets') {
-  echo 'Running scss-lint'
-  sh("bundle exec scss-lint ${dirs}")
-}
-
-/**
  * Check for postgres 9.6 features: jsonb and brin
  */
 def postgres96Linter(String base = 'master', String file = 'db/schema.rb') {
@@ -788,13 +764,6 @@ def hasAssets() {
  */
 def hasRubocop() {
   sh(script: "grep 'rubocop' Gemfile.lock", returnStatus: true) == 0
-}
-
-/**
- * Does this project use scss-lint?
- */
-def hasSCSSLint() {
-  sh(script: "grep 'scss_lint' Gemfile.lock", returnStatus: true) == 0
 }
 
 /**


### PR DESCRIPTION
Trello: https://trello.com/c/MeG1zc2m/195-roll-out-stylelint-config-gds-across-govuk

GOV.UK has migrated to using a node based linter,
https://github.com/alphagov/stylelint-config-gds, there are no longer
projects that use this automatic scss linting approach so the code can
be removed.