### PR TITLE
Remove non-functioning postgres96Lint

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,6 @@ extraParameters | Provide details here of any extra parameters that can be used 
 extraRubyVersions | Ruby versions to run the tests against in addition to the versions currently supported by all GOV.UK applications. Only applies to gems because they may be used in projects with different Ruby versions. | `[]`
 gemName | If publishing a Rubygem, you can specify the Gem name. | Repository name
 overrideTestTask | A closure containing commands to run to test the project. This will run instead of the default `bundle exec rake` |
-postgres96Lint | Whether or not to forbid newer postgres features | `true`
 publishingE2ETests | Whether or not to run the Publishing end-to-end tests. | `false`
 sassLint | Whether or not to run the SASS linter | `true`
 skipDeployToIntegration | Whether or not to skip the "Deploy to integration" stage | `false`

--- a/vars/govuk.groovy
+++ b/vars/govuk.groovy
@@ -174,12 +174,6 @@ def nonDockerBuildTasks(options, jobName, repoName) {
     echo "WARNING: You do not have scss-lint installed."
   }
 
-  if (options.postgres96Lint != false) {
-    stage("Check for Postgres 9.6 features") {
-      postgres96Linter()
-    }
-  }
-
   if (options.beforeTest) {
     echo "Running pre-test tasks"
     options.beforeTest.call()
@@ -564,15 +558,6 @@ def sassLinter(String dirs = 'app/assets/stylesheets') {
 def lintSCSS(String dirs = 'app/assets/stylesheets') {
   echo 'Running scss-lint'
   sh("bundle exec scss-lint ${dirs}")
-}
-
-/**
- * Check for postgres 9.6 features: jsonb and brin
- */
-def postgres96Linter(String base = 'master', String file = 'db/schema.rb') {
-  echo 'Running Postgres 9.6 linter'
-  sh("! git diff master ${base} -- ${file} | grep -i brin")
-  sh("! git diff master ${base} -- ${file} | grep -i jsonb")
 }
 
 /**


### PR DESCRIPTION
This check hasn't worked for a long time. For example:

```
[Pipeline] stage
[Pipeline] { (Check for Postgres 9.6 features)
[Pipeline] echo
Running Postgres 9.6 linter
[Pipeline] sh
+ git diff master master -- db/schema.rb
+ fatal: bad revision 'master'
grep -i brin
[Pipeline] sh
+ git diff master master -- db/schema.rb
+ grep -i jsonb
fatal: bad revision 'master'
[Pipeline] }
[Pipeline] // stage
```

There seems to be two problems: 1) Jenkins does a shallow checkout so
branches can't be found and 2) it seems to try compare master with
master so I'm not sure it could ever find a difference 🤷‍♂️.

Since I think it's exceedingly rare that GOV.UK apps are using Postgres
< 9.6 I don't think there is a need for this any longer.