### PR TITLE
Detect and install yarn dependencies automatically

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,3 +78,4 @@ postgres96Lint | Whether or not to forbid newer postgres features | `true`
 publishingE2ETests | Whether or not to run the Publishing end-to-end tests. | `false`
 sassLint | Whether or not to run the SASS linter | `true`
 skipDeployToIntegration | Whether or not to skip the "Deploy to integration" stage | `false`
+yarnInstall | Whether or not to install Yarn dependencies if a yarn.lock file is found | `true`

--- a/vars/govuk.groovy
+++ b/vars/govuk.groovy
@@ -166,6 +166,12 @@ def nonDockerBuildTasks(options, jobName, repoName) {
     }
   }
 
+  if (options.yarnInstall != false && fileExists(file: "yarn.lock")) {
+    stage("yarn install") {
+      sh("yarn install --frozen-lockfile")
+    }
+  }
+
   if (hasAssets() && hasSCSSLint() && options.sassLint != false) {
     stage("Lint SCSS") {
       lintSCSS()


### PR DESCRIPTION
Trello: https://trello.com/c/MeG1zc2m/195-roll-out-stylelint-config-gds-across-govuk

It's common for GOV.UK Rails apps to have yarn dependencies, currently
many any apps have a hook of: `beforeTest: { sh("yarn install") },`. The
changes in this commit will mean this can be removed.