### PR TITLE
Update conditional to include `main` branch

### DIFF
--- a/vars/govuk.groovy
+++ b/vars/govuk.groovy
@@ -113,7 +113,7 @@ def buildProject(Map options = [:]) {
       nonDockerBuildTasks(options, jobName, repoName)
     }
 
-    if (env.BRANCH_NAME == "master" && !params.IS_SCHEMA_TEST) {
+    if ((env.BRANCH_NAME == "master" || env.BRANCH_NAME == "main") && !params.IS_SCHEMA_TEST) {
       if (isGem()) {
         stage("Publish Gem to Rubygems") {
           publishGem(gemName, repoName, env.BRANCH_NAME)


### PR DESCRIPTION
Updates a conditional to look for either `master` or `main` branch. This will allow gems - like GOV.UK Publishing Components - to rename the primary branch to `main` without breaking things for repos that are still using the name `master`.