### PR TITLE
Set-up for handling non-master default branches

### DIFF
--- a/vars/govuk.groovy
+++ b/vars/govuk.groovy
@@ -123,7 +123,7 @@ def buildProject(Map options = [:]) {
     if (env.BRANCH_NAME == defaultBranch && !params.IS_SCHEMA_TEST) {
       if (isGem()) {
         stage("Publish Gem to Rubygems") {
-          publishGem(gemName, repoName, env.BRANCH_NAME)
+          publishGem(gemName, repoName, env.BRANCH_NAME, defaultBranch)
         }
       } else {
         stage("Push release tag") {

--- a/vars/govuk.groovy
+++ b/vars/govuk.groovy
@@ -93,7 +93,7 @@ def buildProject(Map options = [:]) {
     }
 
     stage("Checkout") {
-      checkoutFromGitHubWithSSH(repoName, [shallow: env.BRANCH_NAME == defaultBranch])
+      checkoutFromGitHubWithSSH(repoName, [shallow: env.BRANCH_NAME != defaultBranch])
     }
 
     stage("Merge ${defaultBranch}") {

--- a/vars/govuk.groovy
+++ b/vars/govuk.groovy
@@ -131,7 +131,7 @@ def buildProject(Map options = [:]) {
 
         if (!options.skipDeployToIntegration) {
           stage("Deploy to integration") {
-            deployIntegration(jobName, env.BRANCH_NAME, "release_${env.BUILD_NUMBER}", 'deploy')
+            deployToIntegration(jobName, "release_${env.BUILD_NUMBER}", 'deploy')
           }
         }
       }
@@ -681,14 +681,20 @@ def pushTag(String repository, String branch, String tag) {
  * @param tag Tag to deploy
  * @param deployTask Deploy task (deploy, deploy:migrations or deploy:setup)
  */
+def deployToIntegration(String application, String tag, String deployTask) {
+  build job: 'Deploy_App_Downstream', parameters: [
+    string(name: 'TARGET_APPLICATION', value: application),
+    string(name: 'TAG', value: tag),
+    string(name: 'DEPLOY_TASK', value: deployTask)
+  ], wait: false
+}
+
+/*
+ * This is a deprecated function that is maintained for a backwards
+ * compatible API
+ */
 def deployIntegration(String application, String branch, String tag, String deployTask) {
-  if (branch == 'master') {
-    build job: 'Deploy_App_Downstream', parameters: [
-      string(name: 'TARGET_APPLICATION', value: application),
-      string(name: 'TAG', value: tag),
-      string(name: 'DEPLOY_TASK', value: deployTask)
-    ], wait: false
-  }
+  deployToIntegration(application, tag, deployTask)
 }
 
 /**


### PR DESCRIPTION
This is a branch that is being used to test out switching some GOV.UK projects from using a `master` branch to a `main` branch. To use it projects need to reference this branch when pulling in Jenkinslib and then specify in `buildProject` that the default branch is `main` - as per https://github.com/alphagov/maslow/pull/670/commits/6c900f74db2d5027bd4d88ea59edfbe23803b3fa

It did seem non-ideal to have to specify the default branch though I found it was a bit tricky to determine the default branch programatically. I found `git ls-remote --symref git@github.com:alphagov/stylelint-config-gds.git HEAD | grep 'ref:' | cut -d$'\t' -f1 | cut -d'/' -f3` (excuse my dubious bash) will do it without cloning the repo, but the git on our CI servers is too old to have `ls-remote`. Otherwise, once cloned, we can do `git remote show origin | grep 'HEAD branch' | cut -d' ' -f5` but you need to have already cloned a repo for that - which is a bit inconvenient given: https://github.com/alphagov/govuk-jenkinslib/blob/d5deab4438d803954ef13f94a2cfa528290932d2/vars/govuk.groovy#L330

---

This allows determining the default branch from the Git repo directly.
It then tries to update the many references to master to be parameters.

This was a bit of a pain to do because all the functions in here may be
used by other GOV.UK projects so should be backwards compatible. This
has made it difficult to do any refactoring and made all these changes
rather convoluted.

A non-backwards compatible change is that deployIntegration no longer
has a guard clause in it. As far as I can tell this is always executed
within a conditional anyway so this doesn't seem of consequence - it
also seems a bit bizarre to have a function that is given a branch as a
parameter and then guard clauses on that only having one value.