### PR TITLE
Fix broken interpolation

### DIFF
--- a/vars/govuk.groovy
+++ b/vars/govuk.groovy
@@ -441,7 +441,7 @@ def checkoutDependent(String repository, options = [:], Closure closure = null) 
  */
 def isCurrentCommitOnBranch(String branch) {
   sh(
-    script: 'git rev-list origin/${branch} | grep $(git rev-parse HEAD)',
+    script: "git rev-list origin/${branch} | grep \$(git rev-parse HEAD)",
     returnStatus: true
   ) == 0
 }


### PR DESCRIPTION
The single quotes don't allow for interpolation which meant the $branch was
treated as undefined shell variable. Switching to double quotes fixes
this and resolves this error we were seeing:

```
+ git rev-list origin/
fatal: ambiguous argument 'origin/': unknown revision or path not in the working tree.
Use '--' to separate paths from revisions, like this:
'git <command> [<revision>...] -- [<file>...]'
+ git rev-parse HEAD
+ grep 7dd2357301eb757a2e4098295dfcfa528c360851
[Pipeline] echo
Current commit is not on main, so attempting merge of main branch before proceeding with build
```