### PR TITLE
Unset RBENV_VERSION after testing against a ruby version

### DIFF
--- a/vars/govuk.groovy
+++ b/vars/govuk.groovy
@@ -677,7 +677,7 @@ def testGemWithAllRubies(extraRubyVersions = []) {
       runTests()
     }
   }
-  sh "unset RBENV_VERSION"
+  env.RBENV_VERSION = ""
 }
 
 /**


### PR DESCRIPTION
Currently we don't sufficiently unset RBENV_VERSION after setting
this environment variable.

This causes the pact tests for gds-api-adapters to fail.

The gds-api-adapters pact tests for Frontend raise the following
error when attempting to bundle install gems:

> Your Ruby version is 2.7.3, but your Gemfile specified 2.7.2

This happens because env.RBENV_VERSION is set to 2.7.3 by the
`testGemWithAllRubies` function in govuk groovy library:
https://github.com/alphagov/govuk-jenkinslib/blob/7d9befbef4b81e889fb7fb9f4562ec9afd730f30/vars/govuk.groovy#L674

All the apps that have pact tests use Ruby 2.7.2 but Frontend
includes the ruby version directive in its Gemfile, causing
bundler to raise an error:
https://github.com/alphagov/frontend/blob/9db830100d1c6712b87f1c7b3fbf646f174b1a66/Gemfile#L2

The solution is to unset the RBENV_VERSION env var. However,
we need to use env.RUBY_VERSION="" rather than the command
`sh("unset RUBY_VERSION")`. I think this is because Jenkins
still keeps the var around in memory despite the global env var
being unset - this doesn't seem well documented.