### PR TITLE
Bundle install before running after step for gems

### DIFF
--- a/vars/govuk.groovy
+++ b/vars/govuk.groovy
@@ -256,6 +256,10 @@ def nonDockerBuildTasks(options, jobName, repoName) {
 
   if (options.afterTest) {
     echo "Running post-test tasks"
+    if (isGem()) {
+      sh "rm -f Gemfile.lock"
+      bundleGem()
+    }
     options.afterTest.call()
   }
 }


### PR DESCRIPTION
testGemWithAllRubies leaves a Gemfile.lock file
generated by an incompatible version of bundler
raising the error:

Could not find 'bundler' (2.1.4) required by your
Gemfile.lock

The solution is to clean up the Gemfile.lock and
re-run bundle install before any afterTests
step if necessary.