### PR TITLE
Add UninstantiatedDescribableWithInterpolation to defaultParameterValuesMap

### DIFF
--- a/vars/govuk.groovy
+++ b/vars/govuk.groovy
@@ -74,7 +74,8 @@ def buildProject(Map options = [:]) {
     // to handle params defined with the xxxParam(...) DSL instead of
     // [$class: ... ] style because we can't call .name / .defaultValue
     // on them directly
-    if (it.class == org.jenkinsci.plugins.structs.describable.UninstantiatedDescribable) {
+    if (it.class == org.jenkinsci.plugins.structs.describable.UninstantiatedDescribable ||
+        it.class == org.jenkinsci.plugins.workflow.cps.UninstantiatedDescribableWithInterpolation) {
       def mapVersionOfIt = it.toMap()
       defaultParameterValuesMap[mapVersionOfIt.name] = mapVersionOfIt.defaultValue
     } else {


### PR DESCRIPTION
Version v2.86 of the `workflow-cps` plugin extended the `UninstantiatedDescribable` class from
the `structs` plugin to store Groovy interpolated strings in an `UninstantiatedDescribableWithInterpolation` class. 

This was causing Jenkins to error immediately when building jobs as we have bespoke behaviour
for `UninstantiatedDescribables` which was not being applied.

This commit ensures we are able to handle both classes when building in Jenkins.

[PR introducing change to workflow-cps](https://github.com/jenkinsci/workflow-cps-plugin/pull/399)

[trello](https://trello.com/c/pCKvKF2J/2583-upgrade-jenkins-plugins-to-versions-without-security-vulnerabilities-5)