### PR TITLE
Update Dockerfile Ruby version check

### DIFF
--- a/vars/govuk.groovy
+++ b/vars/govuk.groovy
@@ -871,7 +871,8 @@ def validateDockerFileRubyVersion() {
 
     // The Dockerfile base image version can be optionally suffixed with a - followed by a variant
     // e.g. ruby:2.4.2-slim
-    def hasMatchingVersions = sh(script: "egrep \"FROM ruby:${rubyVersion}(\$|-)\" Dockerfile", returnStatus: true) == 0
+    def hasMatchingVersions = sh(script: "egrep \"FROM ruby:${rubyVersion}(\$|-)\" Dockerfile", returnStatus: true) == 0 ||
+      sh(script: "egrep \"ARG base_image=ruby:${rubyVersion}(\$|-)\" Dockerfile", returnStatus: true) == 0
     if (!hasMatchingVersions) {
       def baseImageDefinition = sh(script: "egrep \"FROM \" Dockerfile", returnStdout: true).trim()
       error("Dockerfile uses base image \"${baseImageDefinition}\", this mismatches .ruby-version \"${rubyVersion}\"")


### PR DESCRIPTION
PR commit updates the Dockerfile Ruby version check to include `ARG base_image=ruby-X.Y.Z`, which we have recently added to allow the base image to use `govuk-ruby` in our `build-images` Concourse pipeline.

Trello: https://trello.com/c/dZQwFSKK