### PR TITLE
Add 'cleanWorkspace' option to clean workspace at beginning of build

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ Parameter | Description | Default
 afterTest | A closure containing commands to run after the test stage, such as report publishing |
 beforeTest | A closure containing commands to run before the test stage, such as environment variable configuration
 brakeman | Whether or not to run the Brakeman security scanner | `true` if a Rails app, otherwise `false`
+cleanWorkspace | Whether to delete the workspace at the beginning of the build | `false`
 extraParameters | Provide details here of any extra parameters that can be used to configure this build.  See: https://jenkins.io/doc/pipeline/steps/workflow-multibranch/#code-properties-code-set-job-properties for details on the format and structure of these extra parameters. |
 extraRubyVersions | Ruby versions to run the tests against in addition to the versions currently supported by all GOV.UK applications. Only applies to gems because they may be used in projects with different Ruby versions. | `[]`
 gemName | If publishing a Rubygem, you can specify the Gem name. | Repository name

--- a/vars/govuk.groovy
+++ b/vars/govuk.groovy
@@ -93,6 +93,12 @@ def buildProject(Map options = [:]) {
       setBuildStatus(jobName, params.SCHEMA_COMMIT, "Downstream ${jobName} job is building on Jenkins", 'PENDING', 'govuk-content-schemas')
     }
 
+    if (options.cleanWorkspace != false) {
+      stage("Clean workspace") {
+        cleanWs()
+      }
+    }
+
     stage("Checkout") {
       checkoutFromGitHubWithSSH(repoName, [shallow: env.BRANCH_NAME != defaultBranch])
     }


### PR DESCRIPTION
The [rails_translation_manager job](https://ci.integration.publishing.service.gov.uk/job/rails_translation_manager/)
passes successfully on new branches, but on every subsequent build
it will fail with a long log of unrelated errors along the lines
of:
> error: wrong index v2 file size in .git/objects/pack/pack-b360de1f7cfbce9b7fa4b4c11ea4dc4daea3d1f7.idx

We've confirmed that manually deleting the workspace for the
master branch for Rails Translation Manager (on a specific ci-agent)
causes the build to clone everything from scratch, so fixes the
issue.

There is a plugin - WS Cleanup - which is installed on all of our
Jenkins environments: https://github.com/alphagov/govuk-puppet/blob/1ee7892b65b2edf91682261186b1b57041e82a8c/hieradata_aws/class/integration/ci_master.yaml#L421-L422
This code change calls the cleanWs() method as per
https://github.com/jenkinsci/ws-cleanup-plugin.

Ideally, we would simply configure workspace deletion in the Jenkins
UI. We can see that for [certain jobs](https://ci.integration.publishing.service.gov.uk/job/Deploy_App_Downstream/configure),
the plugin provides an option to "Delete workspace before build starts".
HOWEVER, there is no such option on the rails_translation_manager job (nor
any job built from the application_build_job.xml.erb template).
We attempted to shoehorn the config option into these jobs in
https://github.com/alphagov/govuk-puppet/pull/11309,
but the changes had no effect, so now we will now offer an option
configurable from the Jenkinsfile.

Trello: https://trello.com/c/Pq7ffzxM/2752-investigate-rails-translation-manager-failing-builds