### PR TITLE
Use single quotes to wrap s3cmd in shell step

### DIFF
--- a/vars/govuk.groovy
+++ b/vars/govuk.groovy
@@ -961,7 +961,7 @@ def uploadArtefactToS3(artefact_path, s3_path){
                     credentialsId: 'govuk-s3-artefact-creds',
                     usernameVariable: 'AWS_ACCESS_KEY_ID',
                     passwordVariable: 'AWS_SECRET_ACCESS_KEY']]){
-    sh "s3cmd --region eu-west-1 --acl-public --access_key $AWS_ACCESS_KEY_ID --secret_key $AWS_SECRET_ACCESS_KEY put $artefact_path $s3_path"
+    sh 's3cmd --region eu-west-1 --acl-public --access_key $AWS_ACCESS_KEY_ID --secret_key $AWS_SECRET_ACCESS_KEY put $artefact_path $s3_path'
   }
 }
 


### PR DESCRIPTION
This PR replaces double quotes for single quotes to wrap the `s3cmd` which is passed to the `sh`ell step, as [recommended by the Jenkins docs](https://www.jenkins.io/doc/book/pipeline/jenkinsfile/#interpolation-of-sensitive-environment-variables) to avoid printing out sensitive data to logs. 

This manifests in our CI builds as a warning on the job status:
![Screenshot 2021-12-14 at 12 07 46](https://user-images.githubusercontent.com/5422487/145995766-6a721abe-7e22-4c42-ad22-e575ded0999d.png)
