### PR TITLE
Fix quoting for local variables

### DIFF
--- a/vars/govuk.groovy
+++ b/vars/govuk.groovy
@@ -961,7 +961,7 @@ def uploadArtefactToS3(artefact_path, s3_path){
                     credentialsId: 'govuk-s3-artefact-creds',
                     usernameVariable: 'AWS_ACCESS_KEY_ID',
                     passwordVariable: 'AWS_SECRET_ACCESS_KEY']]){
-    sh 's3cmd --region eu-west-1 --acl-public --access_key $AWS_ACCESS_KEY_ID --secret_key $AWS_SECRET_ACCESS_KEY put $artefact_path $s3_path'
+    sh 's3cmd --region eu-west-1 --acl-public --access_key $AWS_ACCESS_KEY_ID --secret_key $AWS_SECRET_ACCESS_KEY put ' + "$artefact_path $s3_path"
   }
 }
 


### PR DESCRIPTION
This PR fixes the `sh` step so that the AWS secrets remain not outputted to logs, whilst allowing Groovy to interpolate `artefact_path` and `s3_path` normally.