### PR TITLE
Accept `ARG ruby_version=` as an alternative to `FROM ruby:`.

### DIFF
--- a/vars/govuk.groovy
+++ b/vars/govuk.groovy
@@ -876,8 +876,8 @@ def validateDockerFileRubyVersion() {
     rubyVersion = rubyVersion.trim().split("-")[0]
 
     // The Dockerfile base image version can be optionally suffixed with a - followed by a variant
-    // e.g. ruby:2.4.2-slim
-    def hasMatchingVersions = sh(script: "egrep \"FROM ruby:${rubyVersion}(\$|-)\" Dockerfile", returnStatus: true) == 0 ||
+    // e.g. ruby:2.4.2-slim. Newer Dockerfiles have an ARG ruby_version=x.y.z.
+    def hasMatchingVersions = sh(script: "egrep -i \"(FROM ruby:|ruby_version=)${rubyVersion}(\$|-)\" Dockerfile", returnStatus: true) == 0 ||
       sh(script: "egrep \"ARG base_image=ruby:${rubyVersion}(\$|-)\" Dockerfile", returnStatus: true) == 0
     if (!hasMatchingVersions) {
       def baseImageDefinition = sh(script: "egrep \"FROM \" Dockerfile", returnStdout: true).trim()


### PR DESCRIPTION
We want to use a better base image than the community-supported Ruby ones, so that we can receive security updates promptly. This test was erronously asserting that we use the community-supported image.

Rollout: requires https://github.com/alphagov/govuk-puppet/pull/11678

Alternatives considered:

I started eliminating this nasty [change-detector] test by simply passing the Ruby version from `.ruby-version` to `docker build`, but then realised it'd be a lot of work to test given that we need to keep supporting the old Dockerfiles for the time being. The test will become obsolete anyway once we've given all the Dockerfiles the Replatforming treatment.

[change-detector]: https://testing.googleblog.com/2015/01/testing-on-toilet-change-detector-tests.html