### PR TITLE
Adds migrateToGithubActions to buildProject.

### DIFF
--- a/vars/govuk.groovy
+++ b/vars/govuk.groovy
@@ -129,19 +129,21 @@ def buildProject(Map options = [:]) {
           publishGem(gemName, repoName, env.BRANCH_NAME, defaultBranch)
         }
       } else {
-        stage("Push release tag") {
-          pushTag(repoName, env.BRANCH_NAME, 'release_' + env.BUILD_NUMBER, defaultBranch)
-        }
-
         if (hasDockerfile() && params.RUN_DOCKER_TASKS) {
           stage("Tag Docker image") {
             dockerTagBranch(jobName, env.BRANCH_NAME, env.BUILD_NUMBER)
           }
         }
 
-        if (!options.skipDeployToIntegration) {
-          stage("Deploy to integration") {
-            deployToIntegration(jobName, "release_${env.BUILD_NUMBER}", 'deploy')
+        if (!options.migrateToGithubActions) {
+          stage("Push release tag") {
+            pushTag(repoName, env.BRANCH_NAME, 'release_' + env.BUILD_NUMBER, defaultBranch)
+          }
+
+          if (!options.skipDeployToIntegration) {
+            stage("Deploy to integration") {
+              deployToIntegration(jobName, "release_${env.BUILD_NUMBER}", 'deploy')
+            }
           }
         }
       }


### PR DESCRIPTION
## What

When migrating to Github actions CI we don't want to create the release tag or deploy to integration because these will be handled in Github actions.

The tests will be still run in Jenkins to allow for comparison between Jenkins and github actions tests.

## Reference 

https://trello.com/c/bF9VStMU/924-move-ci-to-github-actions