### PR TITLE
Use new Docker Enterprise user

### DIFF
--- a/vars/govuk.groovy
+++ b/vars/govuk.groovy
@@ -920,7 +920,7 @@ def dockerTagMasterBranch(jobName, branchName, buildNumber) {
  */
 def pushDockerImage(imageName, tagName, asTag = null) {
   tagName = safeDockerTag(tagName)
-  docker.withRegistry('https://index.docker.io/v1/', 'govukci-docker-hub') {
+  docker.withRegistry('https://index.docker.io/v1/', 'govukci-docker-enterprise-hub') {
     docker.image("govuk/${imageName}:${tagName}").push(asTag ?: tagName)
   }
 }


### PR DESCRIPTION
We have a new user `govukdockerci` which has been added to our
Enterprise hub and is an owner of the `govuk` organisation.
This should allow us to push without any limits. We will continue
to push to the existing govuk organisation that is owned by the
`govukci` user.

This avoids the disruption of having to recreate all the repos in
the governmentdigitalservice org which is shared across GDS.

The credentials have been added in [Jenkins CI](https://ci.integration.publishing.service.gov.uk/credentials/)
and has passed testing a [branch of government-frontend](https://github.com/alphagov/government-frontend/commit/4db1ceb9e47108eb5c9aca502f686d05a9c02b65),
see [console output](https://ci.integration.publishing.service.gov.uk/job/government-frontend/job/test-using-docker-enterprise-acc/6/console) and [image in Docker](https://hub.docker.com/layers/252173238/govuk/government-frontend/test-using-docker-enterprise-acc/images/sha256-668c1db12f58938a41050865a02619b08199b21979b9a2c7b3c6e1382fb6aa54?context=repo).

As I understand we only use Dockerhub as a way to share images with
publishing-e2e-tests. So once these are removed [1] this quirk can be
removed.

[1]: https://github.com/alphagov/publishing-e2e-tests/commit/f0d0d56185cf0bb4bd90c83ec78d085e25032de7

Co-authored-by: Kevin Dew <kevin.dew@digital.cabinet-office.gov.uk>

Related PR: https://github.com/alphagov/govuk-puppet/pull/11750

Trello card: https://trello.com/c/I2IRWNSU/2897-look-into-docker-pull-rate-limits-3