### PR TITLE
Replace deprecated commands with bundler suggestions

### DIFF
--- a/vars/govuk.groovy
+++ b/vars/govuk.groovy
@@ -642,7 +642,10 @@ def availableProcessors() {
 def bundleApp() {
   echo 'Bundling'
   lock ("bundle_install-$NODE_NAME") {
-    sh("bundle install --jobs=${availableProcessors()} --path ${JENKINS_HOME}/bundles --deployment --without development")
+    sh("bundle config set --local path '${JENKINS_HOME}/bundles'")
+    sh("bundle config set --local deployment 'true'")
+    sh("bundle config set --local without 'development'")
+    sh("bundle install --jobs=${availableProcessors()}")
   }
 }
 
@@ -652,7 +655,8 @@ def bundleApp() {
 def bundleGem() {
   echo 'Bundling'
   lock ("bundle_install-$NODE_NAME") {
-    sh("bundle install --jobs=${availableProcessors()} --path ${JENKINS_HOME}/bundles")
+    sh("bundle config set --local path '${JENKINS_HOME}/bundles'")
+    sh("bundle install --jobs=${availableProcessors()}")
   }
 }
 


### PR DESCRIPTION
Trello: https://trello.com/c/0FiI21om/2893-install-ruby-version-31-5

This change resolves two things:

1) It fixes a problem with newer versions of bundler that have a feature
   of installing the requested version of bundler [1] and re-running
   with that version (using the old command causes a write access issue:
   Bundler::SudoNotPermittedError: Bundler requires sudo access to install at
   the moment. Try installing again, granting Bundler sudo access when
   prompted, or installing into a different path.)
2) It stops each build outputting deprecation warnings such as
   `[DEPRECATED] The `--deployment` flag is deprecated because it relies
   on being remembered across bundler invocations, which bundler will no
   longer do in future versions. Instead please use `bundle config set
   --local deployment 'true'`, and stop using this flag`

The known downside to doing this is that we lose the ability to run old
versions of bundle that don't support this argument. However this
concern should only be a problem for software running on EOL versions of
Ruby - as the earliest non-EOL version of Ruby
(2.7) is packaged with Bundler 2.1.2 and these deprecations were
introduced in Bundler 2.1.0.