### PR TITLE
Revert "Replace deprecated commands with bundler suggestions"

### DIFF
--- a/vars/govuk.groovy
+++ b/vars/govuk.groovy
@@ -642,10 +642,7 @@ def availableProcessors() {
 def bundleApp() {
   echo 'Bundling'
   lock ("bundle_install-$NODE_NAME") {
-    sh("bundle config set --local path '${JENKINS_HOME}/bundles'")
-    sh("bundle config set --local deployment 'true'")
-    sh("bundle config set --local without 'development'")
-    sh("bundle install --jobs=${availableProcessors()}")
+    sh("bundle install --jobs=${availableProcessors()} --path ${JENKINS_HOME}/bundles --deployment --without development")
   }
 }
 
@@ -655,8 +652,7 @@ def bundleApp() {
 def bundleGem() {
   echo 'Bundling'
   lock ("bundle_install-$NODE_NAME") {
-    sh("bundle config set --local path '${JENKINS_HOME}/bundles'")
-    sh("bundle install --jobs=${availableProcessors()}")
+    sh("bundle install --jobs=${availableProcessors()} --path ${JENKINS_HOME}/bundles")
   }
 }
 


### PR DESCRIPTION
Reverts alphagov/govuk-jenkinslib#98

I'd forgotten we still support Ruby 1.9.3 (😱) for govuk-puppet. So this is going to need to be more complex in order to support both old and new rubies.