### PR TITLE
Add support for GOV.UK Ruby base images in Docker ruby version check

### DIFF
--- a/vars/govuk.groovy
+++ b/vars/govuk.groovy
@@ -903,7 +903,7 @@ def validateDockerFileRubyVersion() {
     // The Dockerfile base image version can be optionally suffixed with a - followed by a variant
     // e.g. ruby:2.4.2-slim. Newer Dockerfiles have an ARG ruby_version=x.y.z.
     def hasMatchingVersions = sh(script: "egrep -i \"(FROM ruby:|ruby_version=)${rubyVersion}(\$|-)\" Dockerfile", returnStatus: true) == 0 ||
-      sh(script: "egrep \"ARG base_image=ruby:${rubyVersion}(\$|-)\" Dockerfile", returnStatus: true) == 0
+      sh(script: "egrep \"ARG base_image=(ruby|ghcr\\.io\\/alphagov\\/govuk-ruby-base):${rubyVersion}(\$|-)\" Dockerfile", returnStatus: true) == 0
     if (!hasMatchingVersions) {
       def baseImageDefinition = sh(script: "egrep \"FROM \" Dockerfile", returnStdout: true).trim()
       error("Dockerfile uses base image \"${baseImageDefinition}\", this mismatches .ruby-version \"${rubyVersion}\"")


### PR DESCRIPTION
This fixes the Docker ruby version check failing if the new GOV.UK Ruby base image is used.

https://trello.com/c/dwXqpVAi/968-base-and-builder-images