### PR TITLE
Push to & pull from governmentdigitalservice Docker org

### DIFF
--- a/vars/govuk.groovy
+++ b/vars/govuk.groovy
@@ -933,7 +933,7 @@ def buildDockerImage(imageName, tagName, quiet = false) {
   validateDockerFileRubyVersion()
   tagName = safeDockerTag(tagName)
   args = "${quiet ? '--quiet' : ''} --pull ."
-  docker.build("govuk/${imageName}:${tagName}", args)
+  docker.build("governmentdigitalservice/${imageName}:${tagName}", args)
 }
 
 def dockerTagBranch(jobName, branchName, buildNumber) {
@@ -954,13 +954,13 @@ def dockerTagMasterBranch(jobName, branchName, buildNumber) {
 }
 
 /*
- * Push the image to the govuk docker hub and tag it. If `asTag` is set then
+ * Push the image to the governmentdigitalservice docker hub and tag it. If `asTag` is set then
  * the image is also tagged with that value otherwise the `tagName` is used.
  */
 def pushDockerImage(imageName, tagName, asTag = null) {
   tagName = safeDockerTag(tagName)
   docker.withRegistry('https://index.docker.io/v1/', 'govukci-docker-enterprise-hub') {
-    docker.image("govuk/${imageName}:${tagName}").push(asTag ?: tagName)
+    docker.image("governmentdigitalservice/${imageName}:${tagName}").push(asTag ?: tagName)
   }
 }
 


### PR DESCRIPTION
We're consolidating all of GDS' Docker account usage so that it goes through governmentdigitalservice. This org has multiple owners and a process for requesting additional seats, etc, unlike the govuk org which has a 3 seat limit.

Second attempt at #109 (previous attempt missed line 936).

https://trello.com/c/6JRYK8hU/2982-push-to-pull-from-governmentdigitalservice-docker-org-3