### PR TITLE
[DO NOT MERGE] Only use the governmentdigitalservice docker hub account and drop the…

### DIFF
--- a/vars/govuk.groovy
+++ b/vars/govuk.groovy
@@ -934,8 +934,6 @@ def buildDockerImage(imageName, tagName, quiet = false) {
   tagName = safeDockerTag(tagName)
   args = "${quiet ? '--quiet' : ''} --pull ."
 
-  // Build for both accounts until everything is migrated
-  docker.build("govuk/${imageName}:${tagName}", args)
   docker.build("governmentdigitalservice/${imageName}:${tagName}", args)
 }
 
@@ -963,13 +961,7 @@ def dockerTagMasterBranch(jobName, branchName, buildNumber) {
 def pushDockerImage(imageName, tagName, asTag = null) {
   tagName = safeDockerTag(tagName)
   docker.withRegistry('https://index.docker.io/v1/', 'govukci-docker-enterprise-hub') {
-    // Push to both accounts until we migrate everything to the new one
-    docker.image("govuk/${imageName}:${tagName}").push(asTag ?: tagName)
-    try {
-      docker.image("governmentdigitalservice/${imageName}:${tagName}").push(asTag ?: tagName)
-    } catch (e) {
-      println("governmentdigitalservice/${imageName} doesn't exist. If you want to push to this org, you must create the repo manually first.")
-    }
+    docker.image("governmentdigitalservice/${imageName}:${tagName}").push(asTag ?: tagName)
   }
 }
 


### PR DESCRIPTION
… govuk one

We're consolidating all of GDS' Docker account usage so that it goes through governmentdigitalservice. This org has multiple owners and a process for requesting additional seats, etc, unlike the govuk org which has a 3 seat limit.

We started building two images and pushing to both accounts in https://github.com/alphagov/govuk-jenkinslib/pull/113

This removes the build and push steps to the govuk account.

https://trello.com/c/6JRYK8hU/2982-push-to-pull-from-governmentdigitalservice-docker-org-3