### PR TITLE
Increase PR commit limit from 30 to 50

### DIFF
--- a/vars/govuk.groovy
+++ b/vars/govuk.groovy
@@ -504,7 +504,7 @@ def mergeIntoBranch(String branch) {
       "branch before proceeding with build"
 
     sshagent(['govuk-ci-ssh-key']) {
-      sh("git fetch --no-tags --depth=30 origin " +
+      sh("git fetch --no-tags --depth=50 origin " +
          "+refs/heads/${branch}:refs/remotes/origin/${branch} " +
          "refs/heads/${env.BRANCH_NAME}:refs/remotes/origin/${env.BRANCH_NAME}")
     }


### PR DESCRIPTION
There is currently an arbitrary limit on the number of commits that are allowed in a PR, since we try to merge the `main` branch in during the CI build, but only pull down the last 30 commits from `main`.

If you have a PR with more than 30 commits, you see the following unhelpful error in CI:

```
+ git merge --no-commit origin/main
fatal: refusing to merge unrelated histories
+ git merge --abort
fatal: There is no merge to abort (MERGE_HEAD missing).
```

I have encountered several times with Whitehall refactoring work where I hit the 30 commit limit. In most cases, I would consider breaking the PR into smaller ones, but it is not always possible (e.g. major refactors where the PR is broken into smaller commits to make reviewing easier, but none of these can be released independently).

Searching for this error on Slack also suggests other developers hit the limit too.

I am increasing this limit to 50 commits, in the hope this should be enough and that it won't affect the speed of CI.