### PR TITLE
Make shallow clones a config option that defaults to false

### DIFF
--- a/vars/govuk.groovy
+++ b/vars/govuk.groovy
@@ -7,6 +7,18 @@ def buildProject(Map options = [:]) {
   def gemName
   def defaultBranch
 
+  // if you have a large repository you'll want to set shallowClone to only clone
+  // a small portion of the repository and save time in build
+  // example: `buildProject(shallowClone: true)` or for only a single branch `buildproject(shallowclone: env.BRANCH_NAME != "main")`
+  def shallowClone = options.shallowClone != null ? options.shallowClone : false
+
+  // if you have a shallow clone you'll be limited in how many commits are
+  // available for a merge into the default branch. This will limit how many
+  // commits can be in a pull request.
+  // This option has no effect if shallowClone is not set
+  // example: `buildproject(shallowclone: env.BRANCH_NAME != "main", mergeDepth: 50)`
+  def mergeDepth = options.mergeDepth || 30
+
   if (options.repoName) {
     repoName = options.repoName
   } else {
@@ -100,11 +112,11 @@ def buildProject(Map options = [:]) {
     }
 
     stage("Checkout") {
-      checkoutFromGitHubWithSSH(repoName, [shallow: env.BRANCH_NAME != defaultBranch])
+      checkoutFromGitHubWithSSH(repoName, [shallow: shallowClone])
     }
 
     stage("Merge ${defaultBranch}") {
-      mergeIntoBranch(defaultBranch)
+      mergeIntoBranch(defaultBranch, [fetchBranch: shallowClone, mergeDepth: options.mergeDepth])
     }
 
     stage("Configure environment") {
@@ -495,7 +507,13 @@ def releaseBranchExists() {
  * history of it, e.g. a previously-merged dev branch or the deployed-to-production
  * branch.
  */
-def mergeIntoBranch(String branch) {
+def mergeIntoBranch(String branch, Map options = [:]) {
+  def defaultOptions = [
+    fetchBranch: false,
+    mergeDepth: 30
+  ]
+  options = defaultOptions << options
+
   if (isCurrentCommitOnBranch(branch)) {
     echo "Current commit is on ${branch}, so building this branch without " +
       "merging in ${branch} branch."
@@ -503,10 +521,12 @@ def mergeIntoBranch(String branch) {
     echo "Current commit is not on ${branch}, so attempting merge of ${branch} " +
       "branch before proceeding with build"
 
-    sshagent(['govuk-ci-ssh-key']) {
-      sh("git fetch --no-tags --depth=30 origin " +
-         "+refs/heads/${branch}:refs/remotes/origin/${branch} " +
-         "refs/heads/${env.BRANCH_NAME}:refs/remotes/origin/${env.BRANCH_NAME}")
+    if (options.fetchBranch) {
+      sshagent(['govuk-ci-ssh-key']) {
+        sh("git fetch --no-tags --depth=${options.mergeDepth} origin " +
+           "+refs/heads/${branch}:refs/remotes/origin/${branch} " +
+           "refs/heads/${env.BRANCH_NAME}:refs/remotes/origin/${env.BRANCH_NAME}")
+      }
     }
     sh("git merge --no-commit origin/${branch} || git merge --abort")
   }


### PR DESCRIPTION
This has been done to prevent the common headaches devs experience when they have a large PR, or collection of PRs that end up being more than 30 commits out of sync with the main branch.

In those cases developers are greeted with a rather unhelpful message of:

```
+ git merge --no-commit origin/main
fatal: refusing to merge unrelated histories
+ git merge --abort
fatal: There is no merge to abort (MERGE_HEAD missing).
```

As we don't have an agreement that there is a commit limit on PRs this arbitrary number is confusing and divisive (easily starts the debate on how big should a PR be).

This changes the approach to default to not having any limit at all and makes the limit an optimisation that repos can opt into. This means that repos calling `govuk.buildProject` will default to cloning an entire repo.

My theory is that there is actually very few GOV.UK repos where the quantity of commits is significant enough that the time spent cloning repos is a noticeable impact in build times (the worst one was govuk-secrets which is now on GitHub Actions). If there is a repo that is big the team owners can configure their call to buildProject to configure their project accordingly.

For example to restore the previous behaviour to a repo you can call govuk.buildProject like so:

```
govuk.buildProject(shallowClone: env.BRANCH_NAME != "main", mergeDepth: 30)
```

Some examples of this running: 

- Without a shallow clone: https://ci.integration.publishing.service.gov.uk/job/content-tagger/job/testing-jenkins-lib/12/
- With a shallow clone: https://ci.integration.publishing.service.gov.uk/job/content-tagger/job/testing-jenkins-lib/11/