### PR TITLE
Remove master branch quirks with shallow cloning

### DIFF
--- a/vars/govuk.groovy
+++ b/vars/govuk.groovy
@@ -445,6 +445,7 @@ def checkoutFromGitHubWithSSH(String repository, Map options = [:]) {
 def checkoutDependent(String repository, options = [:], Closure closure = null) {
   def defaultOptions = [
     branch: "master",
+    shallow: true,
     changelog: false,
     directory: "tmp/${repository}",
     poll: false

--- a/vars/govuk.groovy
+++ b/vars/govuk.groovy
@@ -444,7 +444,7 @@ def checkoutFromGitHubWithSSH(String repository, Map options = [:]) {
  */
 def checkoutDependent(String repository, options = [:], Closure closure = null) {
   def defaultOptions = [
-    branch: "master",
+    branch: "main",
     shallow: true,
     changelog: false,
     directory: "tmp/${repository}",

--- a/vars/govuk.groovy
+++ b/vars/govuk.groovy
@@ -384,7 +384,7 @@ def checkoutFromGitHubWithSSH(String repository, Map options = [:]) {
     branch: null,
     changelog: true,
     location: null,
-    shallow: env.BRANCH_NAME != "master",
+    shallow: false,
     org: "alphagov",
     poll: true,
     host: "github.com"


### PR DESCRIPTION
This removes some quirky behaviour left for master branch handling, to reflect our switch to main as the default branch.

It removes a choice of shallow or not clone based on master branch and defaults to false, to continue the pattern that shallow clones are opted into. 

It defaults to shallow cloning a dependent branch since these are not going to need to be merged (at least in circumstances I can think of)