### PR TITLE
Reduce the number of builds stored per branch to 30

### DIFF
--- a/vars/govuk.groovy
+++ b/vars/govuk.groovy
@@ -75,7 +75,7 @@ def buildProject(Map options = [:]) {
 
   properties([
     buildDiscarder(
-      logRotator(numToKeepStr: '50')
+      logRotator(numToKeepStr: '30')
     ),
     [$class: 'RebuildSettings', autoRebuild: false, rebuildDisabled: false],
     [$class: 'ParametersDefinitionProperty', parameterDefinitions: parameterDefinitions],


### PR DESCRIPTION
50 seems a rather high number, particularly as we have disk space issues on our CI environment.

I can't imagine there are many scenarios where someone needs to look at a build 50 back from the most recent one.