### PR TITLE
Remove Publishing E2E tests from CI pipelines

### DIFF
--- a/vars/govuk.groovy
+++ b/vars/govuk.groovy
@@ -61,14 +61,6 @@ def buildProject(Map options = [:]) {
     )
   ]
 
-  if (options.publishingE2ETests == true && env.PUBLISHING_E2E_TESTS_BRANCH == null) {
-    parameterDefinitions << stringParam(
-      name: "PUBLISHING_E2E_TESTS_BRANCH",
-      defaultValue: "test-against",
-      description: "The branch of publishing-e2e-tests to test against"
-    )
-  }
-
   if (options.extraParameters) {
     parameterDefinitions.addAll(options.extraParameters)
   }
@@ -255,27 +247,6 @@ def nonDockerBuildTasks(options, jobName, repoName) {
           allowEmptyResults: true
         )
       }
-    }
-  }
-
-  if (options.publishingE2ETests == true && !params.IS_SCHEMA_TEST) {
-    stage("End-to-end tests") {
-      if ( env.PUBLISHING_E2E_TESTS_APP_PARAM == null ) {
-        appCommitishName = jobName.replace("-", "_").toUpperCase() + "_COMMITISH"
-      } else {
-        appCommitishName = env.PUBLISHING_E2E_TESTS_APP_PARAM
-      }
-      if ( env.PUBLISHING_E2E_TESTS_BRANCH == null ) {
-        testBranch = "test-against"
-      } else {
-        testBranch = env.PUBLISHING_E2E_TESTS_BRANCH
-      }
-      if ( env.PUBLISHING_E2E_TESTS_COMMAND == null ) {
-        testCommand = "test"
-      } else {
-        testCommand = env.PUBLISHING_E2E_TESTS_COMMAND
-      }
-      runPublishingE2ETests(appCommitishName, testBranch, repoName, testCommand)
     }
   }
 
@@ -1054,28 +1025,6 @@ def setBuildStatus(jobName, commit, message, state, repoName) {
       errorHandlers: [[$class: "ChangingBuildStatusErrorHandler", result: "UNSTABLE"]],
       statusResultSource: [ $class: "ConditionalStatusResultSource", results: [[$class: "AnyBuildResult", message: message, state: state]] ]
   ]);
-}
-
-def runPublishingE2ETests(appCommitishName, testBranch, repo, testCommand = "test") {
-  fullCommitHash = getFullCommitHash()
-  build(
-    job: "publishing-e2e-tests/${testBranch}",
-    parameters: [
-      [$class: "StringParameterValue",
-       name: appCommitishName,
-       value: fullCommitHash],
-      [$class: "StringParameterValue",
-       name: "TEST_COMMAND",
-       value: testCommand],
-      [$class: "StringParameterValue",
-       name: "ORIGIN_REPO",
-       value: repo],
-      [$class: "StringParameterValue",
-       name: "ORIGIN_COMMIT",
-       value: fullCommitHash]
-    ],
-    wait: false,
-  )
 }
 
 def getFullCommitHash() {


### PR DESCRIPTION
## Context

We're decommissioning the [Publishing E2E tests][] now that GOV.UK apps have transitioned to a model of continuous deployment with contract tests, as outlined in [RFC-128][]. The overall progress of this work is tracked in a [Trello card on the GOV.UK Tech Debt board][tech-debt-card].

## What this PR does

This PR removes functionality from the `govuk.buildProject()` method that triggers the Publishing E2E tests to run against PRs in app repos. It stops the option `publishingE2ETests: true` from having any effect in the CI pipeline, as we no longer need them to run.

A [separate card exists][jenkinsfile-card] to tidy up the Jenkinsfile for each affected application.

[Publishing E2E tests]: https://github.com/alphagov/publishing-e2e-tests
[RFC-128]: https://github.com/alphagov/govuk-rfcs/blob/main/rfc-128-continuous-deployment.md#delete-publishing-e2e-tests
[tech-debt-card]: https://trello.com/c/Lbw4TTfD/233-publishing-e2e-tests-still-exist
[jenkinsfile-card]: https://trello.com/c/qgR41OnR/837-disable-publishing-end-to-end-tests-on-ci-pipelines