### PR TITLE
Remove deprecated functions that are no longer used

### DIFF
--- a/vars/govuk.groovy
+++ b/vars/govuk.groovy
@@ -448,16 +448,6 @@ def isCurrentCommitOnBranch(String branch) {
 }
 
 /**
- * Check if the git HEAD is ahead of master.
- *
- * This is a deprecated function that is maintained for a backwards
- * compatible API
- */
-def isCurrentCommitOnMaster() {
-  isCurrentCommitOnBranch("master")
-}
-
-/**
  * Check whether there is a git branch named release
  * This test is useful for determining whether we should update this branch or
  * not
@@ -503,16 +493,6 @@ def mergeIntoBranch(String branch, Map options = [:]) {
     sh("git merge --no-commit origin/${branch} || git merge --abort")
   }
 
-}
-
-/**
- * Try to merge master into the current branch
- *
- * This is a deprecated function that is maintained for a backwards
- * compatible API
- */
-def mergeMasterBranch() {
-  mergeIntoBranch("master")
 }
 
 /**
@@ -938,14 +918,6 @@ def dockerTagBranch(jobName, branchName, buildNumber) {
   if (releaseBranchExists()) {
     pushDockerImage(jobName, branchName, "release")
   }
-}
-
-/*
- * This is a deprecated function that is maintained for a backwards
- * compatible API
- */
-def dockerTagMasterBranch(jobName, branchName, buildNumber) {
-  dockerTagBranch(jobName, branchName, buildNumber)
 }
 
 /*


### PR DESCRIPTION
Trello: https://trello.com/c/amnaU0V9/853-decommission-the-publishing-end-to-end-tests

These functions are no longer used (confirmed by search on sourcegraph [1]) so can be removed from this repository.

There is one function that is deprecated that I left: deployIntegration as I found a number of references to that still [2].

[1]: https://sourcegraph.com/search?q=context:global+repo:alphagov&patternType=standard
[2]: https://sourcegraph.com/search?q=context:global+repo:alphagov+deployIntegration&patternType=standard