### PR TITLE
Remove deployIntegration function

### DIFF
--- a/vars/govuk.groovy
+++ b/vars/govuk.groovy
@@ -781,14 +781,6 @@ def isSmokey(repoName) {
   repoName == 'smokey'
 }
 
-/*
- * This is a deprecated function that is maintained for a backwards
- * compatible API
- */
-def deployIntegration(String application, String branch, String tag, String deployTask) {
-  deployToIntegration(application, tag, deployTask)
-}
-
 /**
  * Publish a gem to rubygems.org
  *

--- a/vars/govuk.groovy
+++ b/vars/govuk.groovy
@@ -761,7 +761,6 @@ def pushTag(String repository, String branch, String tag, String defaultBranch =
  * @param application ID of the application, which should match the ID
  *        configured in puppet and which is usually the same as the repository
  *        name
- * @param branch Branch name
  * @param tag Tag to deploy
  * @param deployTask Deploy task (deploy, deploy:migrations or deploy:setup)
  */


### PR DESCRIPTION
Trello: https://trello.com/c/amnaU0V9/853-decommission-the-publishing-end-to-end-tests

This was left for backwards compatibility, there are PR's open to remove
their usages:

- https://github.com/alphagov/router/pull/302
- https://github.com/alphagov/ckanext-datagovuk/pull/1178
- https://github.com/alphagov/govuk-content-schemas/pull/1132
- https://github.com/alphagov/govuk_crawler_worker/pull/137

Once they are merged this can be merged.