### PR TITLE
Add Licence reference in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,3 +65,7 @@ gemName | If publishing a Rubygem, you can specify the Gem name. | Repository na
 overrideTestTask | A closure containing commands to run to test the project. This will run instead of the default `bundle exec rake` |
 skipDeployToIntegration | Whether or not to skip the "Deploy to integration" stage | `false`
 yarnInstall | Whether or not to install Yarn dependencies if a yarn.lock file is found | `true`
+
+## Licence
+
+[MIT License](LICENCE)


### PR DESCRIPTION
We want to make the reference to the licence in the README consistent with the GDS Way.

Trello card: https://trello.com/c/P0DpFcwW/260-standardise-all-license-files-names-to-licence