### PR TITLE
Run schema tests against "main" branch of Publishing API

### DIFF
--- a/vars/govuk.groovy
+++ b/vars/govuk.groovy
@@ -34,7 +34,7 @@ def buildProject(Map options = [:]) {
     ),
     stringParam(
       name: 'SCHEMA_BRANCH',
-      defaultValue: 'deployed-to-production',
+      defaultValue: 'main',
       description: 'The branch of publishing api to use for schemas in test'
     ),
     stringParam(
@@ -529,7 +529,7 @@ def precompileAssets() {
 /**
  * Clone publishing api containing content-schemas dependency for contract tests
  */
-def publishingApiDependency(String schemaGitCommit = 'deployed-to-production') {
+def publishingApiDependency(String schemaGitCommit = 'main') {
   checkoutDependent("publishing-api", [ branch: schemaGitCommit ]) {
     setEnvar("GOVUK_CONTENT_SCHEMAS_PATH", "${pwd()}/content_schemas" )
   }


### PR DESCRIPTION
The concept of the "deployed-to-production" branch no longer exists in GOV.UK infrastructure since we switched to a Kubernetes platform. Thus this branch is stale and no-longer represents the deployed version of Publishing API.

Switching this to "main" means that we will be testing against the version of Publishing API that is expected to be deployed - as Publishing API is continuously deployed.